### PR TITLE
User API 테스트까지 완료

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,0 +1,51 @@
+[[Auth]]
+== Auth API
+=== Auth: 회원 가입
+====
+.Request
+include::{snippets}/signup/200/http-request.adoc[]
+.Request Body
+include::{snippets}/signup/200/request-fields.adoc[]
+.Response
+include::{snippets}/signup/200/http-response.adoc[]
+.Error Response
+include::{snippets}/signup/400-0001/http-response.adoc[]
+include::{snippets}/signup/409-9001/http-response.adoc[]
+====
+
+=== Auth: 로그인
+====
+.Request
+include::{snippets}/login/200/http-request.adoc[]
+.Request Body
+include::{snippets}/login/200/request-fields.adoc[]
+.Response
+include::{snippets}/login/200/http-response.adoc[]
+.Error Response
+include::{snippets}/login/401-1001/http-response.adoc[]
+====
+
+=== Auth: 토큰 재발급
+====
+재발급되는 refresh 토큰을 담는 쿠키의 종류는 기존과 동일하게 유지됩니다.
+
+.Request
+include::{snippets}/refresh/200/http-request.adoc[]
+.Request Cookie
+include::{snippets}/refresh/200/request-cookies.adoc[]
+.Response
+include::{snippets}/refresh/200/http-response.adoc[]
+.Error Response
+include::{snippets}/refresh/400-0002-no-cookie/http-response.adoc[]
+include::{snippets}/refresh/401-1002/http-response.adoc[]
+====
+
+=== Auth: 로그아웃
+====
+기존의 토큰이 만료되지 않습니다. Secure 쿠키를 없애는 용도로 사용하시면 됩니다.
+
+.Request
+include::{snippets}/logout/200/http-request.adoc[]
+.Response
+include::{snippets}/logout/200/http-response.adoc[]
+====

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -13,9 +13,9 @@
 서버 상태 확인 용도로, 토큰이 필요하지 않습니다.
 ====
 .Request
-include::{snippets}/auth-ping/200/http-request.adoc[]
+include::{snippets}/ping/200/http-request.adoc[]
 .Response
-include::{snippets}/auth-ping/200/http-response.adoc[]
+include::{snippets}/ping/200/http-response.adoc[]
 ====
 
 === Auth-Ping API
@@ -45,44 +45,4 @@ include::{snippets}/auth-ping/403-3001/http-response.adoc[]
 ====
 
 
-[[Auth]]
-== Auth API
-
-[[Signup]]
-=== Auth: 회원 가입
-====
-.Request
-include::{snippets}/signup/200/http-request.adoc[]
-.Request Body
-include::{snippets}/signup/200/request-fields.adoc[]
-.Response
-include::{snippets}/signup/200/http-response.adoc[]
-.Error Response
-include::{snippets}/signup/400-0001/http-response.adoc[]
-include::{snippets}/signup/409-9001/http-response.adoc[]
-====
-
-=== Auth: 로그인
-====
-.Request
-include::{snippets}/login/200/http-request.adoc[]
-.Request Body
-include::{snippets}/login/200/request-fields.adoc[]
-.Response
-include::{snippets}/login/200/http-response.adoc[]
-.Error Response
-include::{snippets}/login/401-1001/http-response.adoc[]
-====
-
-=== Auth: 토큰 재발급
-====
-.Request
-include::{snippets}/refresh/200/http-request.adoc[]
-.Request Cookie
-include::{snippets}/refresh/200/request-cookies.adoc[]
-.Response
-include::{snippets}/refresh/200/http-response.adoc[]
-.Error Response
-include::{snippets}/refresh/400-0002-no-cookie/http-response.adoc[]
-include::{snippets}/refresh/401-1002/http-response.adoc[]
-====
+include::auth.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -46,3 +46,4 @@ include::{snippets}/auth-ping/403-3001/http-response.adoc[]
 
 
 include::auth.adoc[]
+include::user.adoc[]

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -1,0 +1,42 @@
+[[User]]
+== User API
+=== User: 내 정보 조회하기
+====
+.Request
+include::{snippets}/getMe/200/http-request.adoc[]
+.Response
+include::{snippets}/getMe/200/http-response.adoc[]
+====
+
+=== User: 내 정보 수정하기
+====
+.Request
+include::{snippets}/patchMe/200/http-request.adoc[]
+.Request Body
+include::{snippets}/patchMe/200/request-fields.adoc[]
+.Response
+include::{snippets}/patchMe/200/http-response.adoc[]
+.Error Response
+include::{snippets}/patchMe/400-0001/http-response.adoc[]
+====
+
+=== User: 내 정보 삭제하기 (탈퇴하기)
+====
+.Request
+include::{snippets}/deleteMe/200/http-request.adoc[]
+.Response
+include::{snippets}/deleteMe/200/http-response.adoc[]
+====
+
+=== User: 다른 유저 정보 조회하기
+====
+.Request
+include::{snippets}/getUser/200/http-request.adoc[]
+.Path Variable
+include::{snippets}/getUser/200/path-parameters.adoc[]
+.Response
+include::{snippets}/getUser/200/http-response.adoc[]
+.Error Response
+include::{snippets}/getUser/400-0003/http-response.adoc[]
+include::{snippets}/getUser/404-4001/http-response.adoc[]
+====

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/user/controller/UserController.kt
@@ -1,10 +1,43 @@
 package com.wafflestudio.webgam.domain.user.controller
 
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import com.wafflestudio.webgam.domain.user.dto.UserDto.PatchRequest
+import com.wafflestudio.webgam.domain.user.dto.UserDto.SimpleResponse
+import com.wafflestudio.webgam.domain.user.service.UserService
+import com.wafflestudio.webgam.global.security.CurrentUser
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Positive
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/users")
-class UserController {
+class UserController(
+    private val userService: UserService,
+) {
+    @GetMapping("/me")
+    fun getMyUserInfo(@CurrentUser myId: Long): ResponseEntity<SimpleResponse> {
+        return ResponseEntity.ok(userService.getMe(myId))
+    }
 
+    @PatchMapping("/me")
+    fun patchMyUserInfo(
+        @CurrentUser myId: Long,
+        @RequestBody @Valid request: PatchRequest
+    ): ResponseEntity<SimpleResponse> {
+        System.err.println(request.toString())
+        return ResponseEntity.ok(userService.patchMe(myId, request))
+    }
+
+    @DeleteMapping("/me")
+    fun deleteMyUserInfo(@CurrentUser myId: Long): ResponseEntity<Any> {
+        userService.deleteMe(myId)
+        return ResponseEntity.ok().build()
+    }
+
+    @GetMapping("/{id}")
+    fun getUserInfo(@PathVariable("id") @Positive userId: Long): ResponseEntity<SimpleResponse> {
+        return ResponseEntity.ok(userService.getUserWithId(userId))
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/user/dto/UserDto.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/user/dto/UserDto.kt
@@ -1,8 +1,17 @@
 package com.wafflestudio.webgam.domain.user.dto
 
 import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.global.common.validation.NullableNotBlank
+import jakarta.validation.constraints.Email
 
 class UserDto {
+    data class PatchRequest(
+        @field:NullableNotBlank
+        val username: String?,
+        @field:Email
+        val email: String?,
+    )
+
     data class SimpleResponse(
         val userId: String,
         val username: String,

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/user/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/user/exception/UserNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.user.exception
+
+import com.wafflestudio.webgam.global.common.exception.ErrorType
+import com.wafflestudio.webgam.global.common.exception.WebgamException
+
+class UserNotFoundException(id: Long): WebgamException.NotFound(ErrorType.NotFound.USER_NOT_FOUND,
+    "User with id $id does not exists.")

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/user/repository/UserRepository.kt
@@ -1,9 +1,10 @@
-package com.wafflestudio.webgam.domain.user.repository;
+package com.wafflestudio.webgam.domain.user.repository
 
 import com.wafflestudio.webgam.domain.user.model.User
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository: JpaRepository<User, Long> {
+    fun findUserById(id: Long): User?
     fun findByUserId(userId: String?): User?
     fun existsByUserIdOrEmail(userId: String, email: String): Boolean
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/user/service/UserService.kt
@@ -1,0 +1,42 @@
+package com.wafflestudio.webgam.domain.user.service
+
+import com.wafflestudio.webgam.domain.user.dto.UserDto.PatchRequest
+import com.wafflestudio.webgam.domain.user.dto.UserDto.SimpleResponse
+import com.wafflestudio.webgam.domain.user.exception.UserNotFoundException
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class UserService(
+    private val userRepository: UserRepository,
+) {
+    fun getMe(myId: Long): SimpleResponse {
+        val me = userRepository.findUserById(myId)!!
+        return SimpleResponse(me)
+    }
+
+    @Transactional
+    fun patchMe(myId: Long, request: PatchRequest): SimpleResponse {
+        val me = userRepository.findUserById(myId)!!
+
+        request.username ?.let { me.username = it }
+        request.email ?.let { me.email = it }
+
+        return SimpleResponse(me)
+    }
+
+    @Transactional
+    fun deleteMe(myId: Long) {
+        val me = userRepository.findUserById(myId)!!
+        me.isDeleted = true
+    }
+
+    fun getUserWithId(userId: Long): SimpleResponse {
+        val user = userRepository.findUserById(userId) ?: throw UserNotFoundException(userId)
+        if (user.isDeleted) throw UserNotFoundException(userId)
+
+        return SimpleResponse(user)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/ErrorType.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/ErrorType.kt
@@ -6,6 +6,7 @@ enum class ErrorType {
         DEFAULT(0),
         INVALID_FIELD(1),
         NO_REFRESH_TOKEN(2),
+        CONSTRAINT_VIOLATION(3),
         ;
 
         override fun code(): Int {
@@ -36,6 +37,7 @@ enum class ErrorType {
 
     enum class NotFound(private val code: Int): Error {
         DEFAULT(4000),
+        USER_NOT_FOUND(4001),
         ;
 
         override fun code(): Int {

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamControllerAdvice.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamControllerAdvice.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.webgam.global.common.exception
 
+import jakarta.validation.ConstraintViolationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -23,6 +24,19 @@ class WebgamControllerAdvice {
             ErrorType.BadRequest.INVALID_FIELD.code(),
             "Invalid request parameter or request body",
             e.fieldErrors.joinToString(separator = " ") { it.field + " " + it.defaultMessage + "." }
+        ), HttpStatus.BAD_REQUEST)
+    }
+
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun constraintViolation(e: ConstraintViolationException): ResponseEntity<ErrorResponse?> {
+        return ResponseEntity(
+            ErrorResponse(
+            ErrorType.BadRequest.CONSTRAINT_VIOLATION.code(),
+            "Constraint violations",
+            e.constraintViolations.joinToString(separator = " ") {
+                it.propertyPath.toString().split('.').last() + " " + it.message + ", but " +
+                        it.invalidValue + "."
+            }
         ), HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamControllerAdvice.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamControllerAdvice.kt
@@ -1,12 +1,10 @@
 package com.wafflestudio.webgam.global.common.exception
 
-import com.wafflestudio.webgam.global.security.exception.NoRefreshTokenException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
-import org.springframework.web.bind.MissingRequestCookieException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -26,11 +24,6 @@ class WebgamControllerAdvice {
             "Invalid request parameter or request body",
             e.fieldErrors.joinToString(separator = " ") { it.field + " " + it.defaultMessage + "." }
         ), HttpStatus.BAD_REQUEST)
-    }
-
-    @ExceptionHandler(MissingRequestCookieException::class)
-    fun noRefreshToken(ignored: MissingRequestCookieException): ResponseEntity<ErrorResponse> {
-        return ResponseEntity(ErrorResponse(NoRefreshTokenException()), HttpStatus.BAD_REQUEST)
     }
 
     @ExceptionHandler(WebgamException.Unauthorized::class)

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/validation/NullableNotBlank.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/validation/NullableNotBlank.kt
@@ -1,0 +1,16 @@
+package com.wafflestudio.webgam.global.common.validation
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.FIELD
+import kotlin.reflect.KClass
+
+@Constraint(validatedBy = [NullableNotBlankValidator::class])
+@Target(FIELD)
+@Retention(RUNTIME)
+annotation class NullableNotBlank(
+    val message: String = "can be nullable but not blank",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/validation/NullableNotBlankValidator.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/validation/NullableNotBlankValidator.kt
@@ -1,0 +1,13 @@
+package com.wafflestudio.webgam.global.common.validation
+
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+
+class NullableNotBlankValidator: ConstraintValidator<NullableNotBlank, String> {
+    override fun isValid(value: String?, context: ConstraintValidatorContext?): Boolean {
+        value ?.let {
+            return value.isNotBlank()
+        }
+        return true
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/config/SecurityConfig.kt
@@ -34,7 +34,7 @@ class SecurityConfig(
     companion object {
         private val CORS_WHITELIST: MutableList<String> = mutableListOf()
         private val GET_WHITELIST: Array<String> = arrayOf("/ping")
-        private val POST_WHITELIST: Array<String> = arrayOf("/signup", "/login/**", "/refresh")
+        private val POST_WHITELIST: Array<String> = arrayOf("/signup", "/login/**", "/logout", "/refresh")
     }
 
     @Value("\${spring.profiles.active}")
@@ -44,9 +44,10 @@ class SecurityConfig(
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .httpBasic().disable()
+            .csrf().disable()
+            .logout().disable()
             .cors().configurationSource(corsConfigurationSource())
             .and()
-            .csrf().disable()
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .exceptionHandling()

--- a/src/main/kotlin/com/wafflestudio/webgam/global/security/dto/AuthDto.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/security/dto/AuthDto.kt
@@ -21,6 +21,7 @@ class AuthDto {
         val userId: String?,
         @field:NotBlank
         val password: String?,
+        val auto : Boolean = false,
     )
 
     data class Response(

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -461,6 +461,14 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_auth_로그아웃">Auth: 로그아웃</a></li>
 </ul>
 </li>
+<li><a href="#User">User API</a>
+<ul class="sectlevel2">
+<li><a href="#_user_내_정보_조회하기">User: 내 정보 조회하기</a></li>
+<li><a href="#_user_내_정보_수정하기">User: 내 정보 수정하기</a></li>
+<li><a href="#_user_내_정보_삭제하기_탈퇴하기">User: 내 정보 삭제하기 (탈퇴하기)</a></li>
+<li><a href="#_user_다른_유저_정보_조회하기">User: 다른 유저 정보 조회하기</a></li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
@@ -506,7 +514,7 @@ pong</code></pre>
 <div class="title">Request</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /auth-ping HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc1MTUyMjY2LCJyb2xlIjoiVVNFUiJ9.WV31cbC9voNQXIkdfaqsw6XswAwnq6LnBDx5-68kMcg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc1MTgzMzExLCJyb2xlIjoiVVNFUiJ9.2ukm6gI_LjnI6MTEMVEyPmTW0818fdL3laKP0vSYGIY
 Host: docs.api.com</code></pre>
 </div>
 </div>
@@ -674,7 +682,7 @@ Host: docs.api.com
 <div class="title">Response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NSwiZXhwIjoxNjc2MzU0NjY1fQ.LwIX78H2I0DOx6iSFRMxosWHRuc6bRnfftDWt5EFQDk; Path=/; HttpOnly; SameSite=None
+Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc2Mzg1NzExfQ.lJgxNQHJTo-EywUUksPAothbG7UKXt2CGwV47ZZWc5Y; Path=/; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 316
 
@@ -685,7 +693,7 @@ Content-Length: 316
     "email" : "foo@wafflestudio.com"
   },
   "message" : "login success",
-  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NSwiZXhwIjoxNjc1MTUyMjY1LCJyb2xlIjoiVVNFUiJ9.75qxboQZuh0cEZwY8BwU_8cMxLKRmM5WFMXRRPD3eMc"
+  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc1MTgzMzExLCJyb2xlIjoiVVNFUiJ9.2ukm6gI_LjnI6MTEMVEyPmTW0818fdL3laKP0vSYGIY"
 }</code></pre>
 </div>
 </div>
@@ -699,7 +707,7 @@ Content-Length: 228
 {
   "error_code" : 1,
   "error_message" : "Invalid request parameter or request body",
-  "detail" : "password must not be blank. email must be a well-formed email address. username must not be blank. userId must not be blank."
+  "detail" : "username must not be blank. password must not be blank. userId must not be blank. email must be a well-formed email address."
 }</code></pre>
 </div>
 </div>
@@ -792,7 +800,7 @@ Host: docs.api.com
 <div class="title">Response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc2MzU0NjY2fQ.GzjPxGQ3f80fSmu2nPNbPbPVx-XqOlVc5B2NfaS6zoU; Path=/; HttpOnly; SameSite=None
+Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc2Mzg1NzExfQ.lJgxNQHJTo-EywUUksPAothbG7UKXt2CGwV47ZZWc5Y; Path=/; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 319
 
@@ -803,7 +811,7 @@ Content-Length: 319
     "email" : "unqiue@wafflestudio.com"
   },
   "message" : "login success",
-  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc1MTUyMjY2LCJyb2xlIjoiVVNFUiJ9.WV31cbC9voNQXIkdfaqsw6XswAwnq6LnBDx5-68kMcg"
+  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc1MTgzMzExLCJyb2xlIjoiVVNFUiJ9.2ukm6gI_LjnI6MTEMVEyPmTW0818fdL3laKP0vSYGIY"
 }</code></pre>
 </div>
 </div>
@@ -836,7 +844,7 @@ Content-Length: 131
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /refresh HTTP/1.1
 Host: docs.api.com
-Cookie: refresh_token=Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc2MzU0NjY2fQ.GzjPxGQ3f80fSmu2nPNbPbPVx-XqOlVc5B2NfaS6zoU
+Cookie: refresh_token=Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc2Mzg1NzExfQ.lJgxNQHJTo-EywUUksPAothbG7UKXt2CGwV47ZZWc5Y
 Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
@@ -863,12 +871,12 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="title">Response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc2MzU0NjY2fQ.GzjPxGQ3f80fSmu2nPNbPbPVx-XqOlVc5B2NfaS6zoU; Path=/; HttpOnly; SameSite=None
+Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc2Mzg1NzExfQ.lJgxNQHJTo-EywUUksPAothbG7UKXt2CGwV47ZZWc5Y; Path=/; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 163
 
 {
-  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc1MTUyMjY2fQ.d3HeoGduYUhFnKSt2sPQm6UfKfeO1VgqM0O7VH9KFVU"
+  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc1MTgzMzExfQ.kvxsSyu22yS_OjCFnbAUpX0Rau9IAbmP9yKo9Rx_-1E"
 }</code></pre>
 </div>
 </div>
@@ -929,11 +937,228 @@ Set-Cookie: refresh_token=; Path=/; Max-Age=0; Expires=Thu, 1 Jan 1970 00:00:00 
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="User"><a class="link" href="#User">User API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_user_내_정보_조회하기"><a class="link" href="#_user_내_정보_조회하기">User: 내 정보 조회하기</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/users/me HTTP/1.1
+Host: docs.api.com</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 83
+
+{
+  "user_id" : "fooId",
+  "username" : "foo",
+  "email" : "foo@wafflestudio.com"
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_user_내_정보_수정하기"><a class="link" href="#_user_내_정보_수정하기">User: 내 정보 수정하기</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/users/me HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 65
+Host: docs.api.com
+
+{
+  "username" : "new_foo",
+  "email" : "foo2@wafflestudio.com"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 4. Request Body</caption>
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필드명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필수여부</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Default 값</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">포맷 및 제약조건</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예시</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>username</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">빈 문자열 X</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저네임</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">빈 문자열 X, 올바른 이메일 형식</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 88
+
+{
+  "user_id" : "fooId",
+  "username" : "new_foo",
+  "email" : "foo2@wafflestudio.com"
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Error Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 186
+
+{
+  "error_code" : 1,
+  "error_message" : "Invalid request parameter or request body",
+  "detail" : "email must be a well-formed email address. username can be nullable but not blank."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_user_내_정보_삭제하기_탈퇴하기"><a class="link" href="#_user_내_정보_삭제하기_탈퇴하기">User: 내 정보 삭제하기 (탈퇴하기)</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/users/me HTTP/1.1
+Host: docs.api.com</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_user_다른_유저_정보_조회하기"><a class="link" href="#_user_다른_유저_정보_조회하기">User: 다른 유저 정보 조회하기</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/users/6 HTTP/1.1
+Host: docs.api.com</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 5. /api/v1/users/{id}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 유저 ID</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 83
+
+{
+  "user_id" : "barId",
+  "username" : "bar",
+  "email" : "bar@wafflestudio.com"
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Error Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 121
+
+{
+  "error_code" : 3,
+  "error_message" : "Constraint violations",
+  "detail" : "userId must be greater than 0, but 0."
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 404 Not Found
+Content-Type: application/json
+Content-Length: 112
+
+{
+  "error_code" : 4001,
+  "error_message" : "USER_NOT_FOUND",
+  "detail" : "User with id 39 does not exists."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-01-31 14:40:35 +0900
+Last updated 2023-01-31 23:34:18 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -455,9 +455,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#Auth">Auth API</a>
 <ul class="sectlevel2">
-<li><a href="#Signup">Auth: 회원 가입</a></li>
+<li><a href="#_auth_회원_가입">Auth: 회원 가입</a></li>
 <li><a href="#_auth_로그인">Auth: 로그인</a></li>
 <li><a href="#_auth_토큰_재발급">Auth: 토큰 재발급</a></li>
+<li><a href="#_auth_로그아웃">Auth: 로그아웃</a></li>
 </ul>
 </li>
 </ul>
@@ -477,8 +478,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="listingblock">
 <div class="title">Request</div>
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /auth-ping HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NDcxNzA2NCwiZXhwIjoxNjc0NzI0MjY0LCJyb2xlIjoiVVNFUiJ9.2THr31YU4g83AgONYuhP6KBHVEbmosVCeE13COXqOBA
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /ping HTTP/1.1
 Host: docs.api.com</code></pre>
 </div>
 </div>
@@ -487,9 +487,9 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: text/plain;charset=UTF-8
-Content-Length: 9
+Content-Length: 4
 
-auth-pong</code></pre>
+pong</code></pre>
 </div>
 </div>
 </div>
@@ -506,7 +506,7 @@ auth-pong</code></pre>
 <div class="title">Request</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /auth-ping HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NDcxNzA2NCwiZXhwIjoxNjc0NzI0MjY0LCJyb2xlIjoiVVNFUiJ9.2THr31YU4g83AgONYuhP6KBHVEbmosVCeE13COXqOBA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc1MTUyMjY2LCJyb2xlIjoiVVNFUiJ9.WV31cbC9voNQXIkdfaqsw6XswAwnq6LnBDx5-68kMcg
 Host: docs.api.com</code></pre>
 </div>
 </div>
@@ -592,7 +592,7 @@ Content-Length: 111
 <h2 id="Auth"><a class="link" href="#Auth">Auth API</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="Signup"><a class="link" href="#Signup">Auth: 회원 가입</a></h3>
+<h3 id="_auth_회원_가입"><a class="link" href="#_auth_회원_가입">Auth: 회원 가입</a></h3>
 <div class="exampleblock">
 <div class="content">
 <div class="listingblock">
@@ -674,7 +674,7 @@ Host: docs.api.com
 <div class="title">Response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: refreshToken=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NDcxNzA2MywiZXhwIjoxNjc1OTI2NjYzfQ.gbG7tBhfYevGm5TLu4SIHsnS9wOCk-9Na3Dzhlc4iP8; Path=/; Max-Age=1209600000; Expires=Thu, 26 May 2061 07:11:03 GMT; HttpOnly; SameSite=None
+Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NSwiZXhwIjoxNjc2MzU0NjY1fQ.LwIX78H2I0DOx6iSFRMxosWHRuc6bRnfftDWt5EFQDk; Path=/; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 316
 
@@ -685,7 +685,7 @@ Content-Length: 316
     "email" : "foo@wafflestudio.com"
   },
   "message" : "login success",
-  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NDcxNzA2MywiZXhwIjoxNjc0NzI0MjYzLCJyb2xlIjoiVVNFUiJ9.duR-fwfeAUovOFmoC-c-U1KNMyP868LxhnesVQ_3Klg"
+  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NSwiZXhwIjoxNjc1MTUyMjY1LCJyb2xlIjoiVVNFUiJ9.75qxboQZuh0cEZwY8BwU_8cMxLKRmM5WFMXRRPD3eMc"
 }</code></pre>
 </div>
 </div>
@@ -699,7 +699,7 @@ Content-Length: 228
 {
   "error_code" : 1,
   "error_message" : "Invalid request parameter or request body",
-  "detail" : "username must not be blank. password must not be blank. userId must not be blank. email must be a well-formed email address."
+  "detail" : "password must not be blank. email must be a well-formed email address. username must not be blank. userId must not be blank."
 }</code></pre>
 </div>
 </div>
@@ -728,12 +728,13 @@ Content-Length: 133
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 52
+Content-Length: 70
 Host: docs.api.com
 
 {
   "user_id" : "fooId",
-  "password" : "password"
+  "password" : "password",
+  "auto" : false
 }</code></pre>
 </div>
 </div>
@@ -776,13 +777,22 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock">로그인 비밀번호</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>auto</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">자동 로그인 여부</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
 </tbody>
 </table>
 <div class="listingblock">
 <div class="title">Response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: refreshToken=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NDcxNzA2NCwiZXhwIjoxNjc1OTI2NjY0fQ.xpjoETadozMLJLDus2nnxOaWWscZaxRnLWxAzq_nD2w; Path=/; Max-Age=1209600000; Expires=Thu, 26 May 2061 07:11:04 GMT; HttpOnly; SameSite=None
+Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc2MzU0NjY2fQ.GzjPxGQ3f80fSmu2nPNbPbPVx-XqOlVc5B2NfaS6zoU; Path=/; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 319
 
@@ -793,7 +803,7 @@ Content-Length: 319
     "email" : "unqiue@wafflestudio.com"
   },
   "message" : "login success",
-  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NDcxNzA2NCwiZXhwIjoxNjc0NzI0MjY0LCJyb2xlIjoiVVNFUiJ9.2THr31YU4g83AgONYuhP6KBHVEbmosVCeE13COXqOBA"
+  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc1MTUyMjY2LCJyb2xlIjoiVVNFUiJ9.WV31cbC9voNQXIkdfaqsw6XswAwnq6LnBDx5-68kMcg"
 }</code></pre>
 </div>
 </div>
@@ -818,12 +828,15 @@ Content-Length: 131
 <h3 id="_auth_토큰_재발급"><a class="link" href="#_auth_토큰_재발급">Auth: 토큰 재발급</a></h3>
 <div class="exampleblock">
 <div class="content">
+<div class="paragraph">
+<p>재발급되는 refresh 토큰을 담는 쿠키의 종류는 기존과 동일하게 유지됩니다.</p>
+</div>
 <div class="listingblock">
 <div class="title">Request</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /refresh HTTP/1.1
 Host: docs.api.com
-Cookie: refresh_token=Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NDcxNzA2NCwiZXhwIjoxNjc1OTI2NjY0fQ.xpjoETadozMLJLDus2nnxOaWWscZaxRnLWxAzq_nD2w
+Cookie: refresh_token=Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc2MzU0NjY2fQ.GzjPxGQ3f80fSmu2nPNbPbPVx-XqOlVc5B2NfaS6zoU
 Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
@@ -850,12 +863,12 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="title">Response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: refreshToken=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NDcxNzA2NCwiZXhwIjoxNjc1OTI2NjY0fQ.xpjoETadozMLJLDus2nnxOaWWscZaxRnLWxAzq_nD2w; Path=/; Max-Age=1209600000; Expires=Thu, 26 May 2061 07:11:04 GMT; HttpOnly; SameSite=None
+Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc2MzU0NjY2fQ.GzjPxGQ3f80fSmu2nPNbPbPVx-XqOlVc5B2NfaS6zoU; Path=/; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 163
 
 {
-  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NDcxNzA2NCwiZXhwIjoxNjc0NzI0MjY0fQ.QcItFmvuY2d2VZ-p4ltvFmYtvYY5GsDiPulNFgNIm9o"
+  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE0NTA2NiwiZXhwIjoxNjc1MTUyMjY2fQ.d3HeoGduYUhFnKSt2sPQm6UfKfeO1VgqM0O7VH9KFVU"
 }</code></pre>
 </div>
 </div>
@@ -889,13 +902,38 @@ Content-Length: 110
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_auth_로그아웃"><a class="link" href="#_auth_로그아웃">Auth: 로그아웃</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="paragraph">
+<p>기존의 토큰이 만료되지 않습니다. Secure 쿠키를 없애는 용도로 사용하시면 됩니다.</p>
+</div>
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /logout HTTP/1.1
+Host: docs.api.com
+Content-Type: application/x-www-form-urlencoded</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Set-Cookie: refresh_token=; Path=/; Max-Age=0; Expires=Thu, 1 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=None</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-01-26 16:10:04 +0900
+Last updated 2023-01-31 14:40:35 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/user/UserDescribeSpec.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/user/UserDescribeSpec.kt
@@ -1,0 +1,203 @@
+package com.wafflestudio.webgam.domain.user
+
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentRequest
+import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentResponse
+import com.wafflestudio.webgam.RestDocsUtils.Companion.requestBody
+import com.wafflestudio.webgam.STRING
+import com.wafflestudio.webgam.domain.user.dto.UserDto
+import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.CONSTRAINT_VIOLATION
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.INVALID_FIELD
+import com.wafflestudio.webgam.global.common.exception.ErrorType.NotFound.USER_NOT_FOUND
+import com.wafflestudio.webgam.global.security.model.UserPrincipal
+import com.wafflestudio.webgam.global.security.model.WebgamAuthenticationToken
+import com.wafflestudio.webgam.type
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.extensions.spring.SpringExtension
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.hamcrest.core.Is.`is`
+import org.junit.jupiter.api.Tag
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@Tag("Integration-Test")
+@DisplayName("User 통합 테스트")
+class UserDescribeSpec(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val userRepository: UserRepository,
+): DescribeSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    companion object {
+        private val gson = GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+        private val validPatchRequest = UserDto.PatchRequest("new_foo", "foo2@wafflestudio.com")
+        private val invalidPatchRequest = UserDto.PatchRequest("  ", "  ")
+    }
+
+    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+        withContext(Dispatchers.IO) {
+            userRepository.deleteAll()
+        }
+    }
+
+    init {
+        this.describe("내 정보 조회할 때") {
+            context("성공하면") {
+                val user = withContext(Dispatchers.IO) {
+                    userRepository.save(User("fooId", "foo", "foo@wafflestudio.com", ""))
+                }
+
+                it("200 OK") {
+                    mockMvc.perform(
+                        get("/api/v1/users/me")
+                            .with(authentication(WebgamAuthenticationToken(UserPrincipal(user), "")))
+                    ).andDo(document(
+                        "getMe/200",
+                        getDocumentRequest(),
+                        getDocumentResponse()
+                    )).andExpect(status().isOk).andDo(print())
+                }
+            }
+        }
+
+        this.describe("내 정보 수정할 때") {
+            context("성공하면") {
+                val user = withContext(Dispatchers.IO) {
+                    userRepository.save(User("fooId", "foo", "foo@wafflestudio.com", ""))
+                }
+
+                it("200 OK") {
+                    mockMvc.perform(
+                        patch("/api/v1/users/me")
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(validPatchRequest))
+                            .with(authentication(WebgamAuthenticationToken(UserPrincipal(user), "")))
+                    ).andDo(document(
+                        "patchMe/200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestBody(
+                            "username" type STRING means "유저네임" formattedAs "빈 문자열 X" isOptional true,
+                            "email" type STRING means "이메일" formattedAs "빈 문자열 X, 올바른 이메일 형식" isOptional true
+                        ))
+                    ).andExpect(status().isOk).andDo(print())
+                }
+            }
+
+            context("올바르지 않은 값을 넣었을 때") {
+                val user = withContext(Dispatchers.IO) {
+                    userRepository.save(User("fooId", "foo", "foo@wafflestudio.com", ""))
+                }
+
+                it("400 Bad Request, 에러코드 ") {
+                    mockMvc.perform(
+                        patch("/api/v1/users/me")
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(invalidPatchRequest))
+                            .with(authentication(WebgamAuthenticationToken(UserPrincipal(user), "")))
+                    ).andDo(document(
+                        "patchMe/400-0001",
+                        getDocumentResponse())
+                    ).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(INVALID_FIELD.code()))
+                    ).andDo(print())
+                }
+            }
+        }
+
+        this.describe("회원 탈퇴할 때") {
+            context("성공하면") {
+                val user = withContext(Dispatchers.IO) {
+                    userRepository.save(User("fooId", "foo", "foo@wafflestudio.com", ""))
+                }
+
+                it("200 OK") {
+                    mockMvc.perform(
+                        delete("/api/v1/users/me")
+                            .with(authentication(WebgamAuthenticationToken(UserPrincipal(user), "")))
+                    ).andDo(document(
+                        "deleteMe/200",
+                        getDocumentRequest(),
+                        getDocumentResponse())
+                    ).andExpect(status().isOk).andDo(print())
+                }
+            }
+        }
+
+        this.describe("다른 회원 정보 조회할 때") {
+            val loginUser = withContext(Dispatchers.IO) {
+                userRepository.save(User("fooId", "foo", "foo@wafflestudio.com", ""))
+            }
+
+            val user = withContext(Dispatchers.IO) {
+                userRepository.save(User("barId", "bar", "bar@wafflestudio.com", ""))
+            }
+
+            context("성공하면") {
+                it("200 OK") {
+                    mockMvc.perform(
+                        get("/api/v1/users/{id}", "${user.id}")
+                            .with(authentication(WebgamAuthenticationToken(UserPrincipal(loginUser), "")))
+                    ).andDo(document(
+                        "getUser/200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(parameterWithName("id").description("조회할 유저 ID")))
+                    ).andExpect(status().isOk).andDo(print())
+                }
+            }
+
+            context("회원 ID를 잘못 입력하는 경우") {
+                it("400 Bad Request, 에러코드 ${CONSTRAINT_VIOLATION.code()}") {
+                    mockMvc.perform(
+                        get("/api/v1/users/{id}", "0")
+                            .with(authentication(WebgamAuthenticationToken(UserPrincipal(loginUser), "")))
+                    ).andDo(document(
+                        "getUser/400-0003",
+                        getDocumentResponse())
+                    ).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(CONSTRAINT_VIOLATION.code()))
+                    ).andDo(print())
+                }
+            }
+
+            context("존재하지 않거나 탈퇴한 회원을 조회하는 경우") {
+                it("404 Not Found, 에러코드 ${USER_NOT_FOUND.code()}") {
+                    mockMvc.perform(
+                        get("/api/v1/users/{id}", (user.id + 33).toString())
+                            .with(authentication(WebgamAuthenticationToken(UserPrincipal(loginUser), "")))
+                    ).andDo(document(
+                        "getUser/404-4001",
+                        getDocumentResponse())
+                    ).andExpect(status().isNotFound
+                    ).andExpect(jsonPath("$.error_code", `is`(USER_NOT_FOUND.code()))
+                    ).andDo(print())
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/user/controller/UserControllerTest.kt
@@ -1,0 +1,186 @@
+package com.wafflestudio.webgam.domain.user.controller
+
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.webgam.domain.user.dto.UserDto.SimpleResponse
+import com.wafflestudio.webgam.domain.user.exception.UserNotFoundException
+import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.domain.user.service.UserService
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.CONSTRAINT_VIOLATION
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.INVALID_FIELD
+import com.wafflestudio.webgam.global.common.exception.ErrorType.NotFound.USER_NOT_FOUND
+import com.wafflestudio.webgam.global.security.model.UserPrincipal
+import com.wafflestudio.webgam.global.security.model.WebgamAuthenticationToken
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.mockk.every
+import io.mockk.justRun
+import org.hamcrest.core.Is
+import org.junit.jupiter.api.Tag
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.*
+
+@WebMvcTest(UserController::class)
+@MockkBean(JpaMetamodelMappingContext::class)
+@ActiveProfiles("test")
+@Tag("Unit-Test")
+@DisplayName("UserController 단위 테스트")
+class UserControllerTest(
+    @Autowired private val mockMvc: MockMvc,
+    @MockkBean private val userService: UserService,
+) : DescribeSpec() {
+
+    companion object {
+        private val gson = GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+        private val user = User("", "", "", "")
+        private val authentication = WebgamAuthenticationToken(UserPrincipal(user), "")
+        private val dummyUser = User("", "", "", "")
+    }
+
+    init {
+        this.describe("내 정보 조회할 때") {
+            every { userService.getMe(any()) } returns SimpleResponse(user)
+
+            context("성공하면") {
+                it("200 OK") {
+                    mockMvc.get("/api/v1/users/me") {
+                        with(authentication(authentication))
+                    }.andExpect { status { isOk() } }
+                }
+            }
+        }
+
+        this.describe("내 정보 수정할 때") {
+            every { userService.patchMe(any(), any()) } returns SimpleResponse(user)
+
+            val validUsernames = mutableListOf("omit", "foo", null)
+            val invalidUsernames = mutableListOf("", "     ")
+            val validEmails = mutableListOf("omit", "foo@wafflestudio.com")
+            val invalidEmails = mutableListOf("foo", "@")
+
+            context("적절한 유저네임과 이메일을 입력하면") {
+                val tuples = validUsernames.map { u -> validEmails.map { e -> u to e } }.flatten()
+
+                it("200 OK") {
+                    tuples.forAll { (username, email) ->
+                        val request = HashMap<String, String?>()
+                        if (username != "omit") request["username"] = username
+                        if (email != "omit") request["email"] = email
+
+                        mockMvc.patch("/api/v1/users/me") {
+                            contentType = MediaType.APPLICATION_JSON
+                            content = gson.toJson(request)
+                            with(authentication(authentication))
+                            with(csrf())
+                        }.andExpect { status { isOk() } }
+                    }
+                }
+            }
+
+            context("적절하지 않은 유저네임을 입력하면") {
+                val tuples = invalidUsernames.map { u -> validEmails.map { e -> u to e } }.flatten()
+
+                it("400 Bad Request, 에러코드 ${INVALID_FIELD.code()}") {
+                    tuples.forAll { (username, email) ->
+                        val request = HashMap<String, String?>()
+                        if (username != "omit") request["username"] = username
+                        if (email != "omit") request["email"] = email
+
+                        mockMvc.patch("/api/v1/users/me") {
+                            contentType = MediaType.APPLICATION_JSON
+                            content = gson.toJson(request)
+                            with(authentication(authentication))
+                            with(csrf())
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", Is.`is`(INVALID_FIELD.code()))
+                        }
+                    }
+                }
+            }
+
+            context("적절하지 않은 이메일을 입력하면") {
+                val tuples = validUsernames.map { u -> invalidEmails.map { e -> u to e } }.flatten()
+
+                it("400 Bad Request, 에러코드 ${INVALID_FIELD.code()}") {
+                    tuples.forAll { (username, email) ->
+                        val request = HashMap<String, String?>()
+                        if (username != "omit") request["username"] = username
+                        if (email != "omit") request["email"] = email
+
+                        mockMvc.patch("/api/v1/users/me") {
+                            contentType = MediaType.APPLICATION_JSON
+                            content = gson.toJson(request)
+                            with(authentication(authentication))
+                            with(csrf())
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", Is.`is`(INVALID_FIELD.code()))
+                        }
+                    }
+                }
+            }
+        }
+
+        this.describe("내 정보 삭제(탈퇴)할 때") {
+            justRun { userService.deleteMe(any()) }
+
+            context("성공하면") {
+                it("200 OK") {
+                    mockMvc.delete("/api/v1/users/me") {
+                        with(authentication(authentication))
+                        with(csrf())
+                    }.andExpect { status { isOk() } }
+                }
+            }
+        }
+
+        this.describe("다른 유저 정보 조회할 때") {
+            context("존재하는 유저 ID를 요청하면") {
+                every { userService.getUserWithId(1) } returns SimpleResponse(dummyUser)
+
+                it("200 OK") {
+                    mockMvc.get("/api/v1/users/{id}", "1") {
+                        with(authentication(authentication))
+                    }.andExpect { status { isOk() } }
+                }
+            }
+
+            context("존재하지 않거나 탈퇴한 유저 ID를 요청하면") {
+                every { userService.getUserWithId(1) } throws UserNotFoundException(1)
+
+                it("404 Not Found, 에러코드 ${USER_NOT_FOUND.code()}") {
+                    mockMvc.get("/api/v1/users/{id}", "1") {
+                        with(authentication(authentication))
+                    }.andExpect {
+                        status { isNotFound() }
+                        jsonPath("$.error_code", Is.`is`(USER_NOT_FOUND.code()))
+                    }
+                }
+            }
+
+            context("ID가 올바르지 않으면") {
+                val userIds = mutableListOf(-1, 0)
+
+                it("400 Bad Request, 에러코드 ${CONSTRAINT_VIOLATION.code()}") {
+                    userIds.forAll { id ->
+                        mockMvc.get("/api/v1/users/{id}", "$id") {
+                            with(authentication(authentication))
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", Is.`is`(CONSTRAINT_VIOLATION.code()))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/user/service/UserServiceTest.kt
@@ -1,0 +1,134 @@
+package com.wafflestudio.webgam.domain.user.service
+
+import com.wafflestudio.webgam.domain.user.dto.UserDto.PatchRequest
+import com.wafflestudio.webgam.domain.user.exception.UserNotFoundException
+import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.assertThrows
+
+@Tag("Unit-Test")
+@DisplayName("UserService 단위 테스트")
+class UserServiceTest: DescribeSpec() {
+
+    companion object {
+        private val user = User("fooId", "foo", "foo@wafflestudio.com", "")
+        private val userRepository = mockk<UserRepository>()
+        private val userService = UserService(userRepository)
+    }
+
+    init {
+        this.describe("getMe 호출될 때") {
+            every { userRepository.findUserById(1) } returns user
+
+            context("현재 로그인 된 유저 아이디를 넣으면") {
+                it("유저의 SimpleResponse 가 반환된다") {
+                    val response = withContext(Dispatchers.IO) {
+                        userService.getMe(1)
+                    }
+
+                    assertThat(response).extracting("userId").isEqualTo("fooId")
+                    assertThat(response).extracting("username").isEqualTo("foo")
+                    assertThat(response).extracting("email").isEqualTo("foo@wafflestudio.com")
+                }
+            }
+        }
+
+        this.describe("patchMe 호출될 때") {
+            context("현재 로그인 된 유저 아이디와 바꿀 항목을 입력하면") {
+                it("수정된 정보의 SimpleResponse 가 반환된다") {
+                    val tuples = mutableListOf("new username" to "new@wafflestudio.com")
+
+                    tuples.forAll { (username, email) ->
+                        val temp = User("fooId", "foo", "foo@wafflestudio.com", "")
+                        every { userRepository.findUserById(1) } returns temp
+
+                        val response = userService.patchMe(1, PatchRequest(username, email))
+
+                        assertThat(response).extracting("userId").isEqualTo("fooId")
+                        assertThat(response).extracting("username").isEqualTo(username)
+                        assertThat(response).extracting("email").isEqualTo(email)
+                    }
+                }
+
+                it("값이 NULL 인 항목들은 바뀌지 않는다") {
+                    val tuples = mutableListOf(
+                        "new username" to null,
+                        null to "new@wafflestudio.com",
+                        null to null,
+                    )
+
+                    tuples.forAll { (username, email) ->
+                        val temp = User("fooId", "foo", "foo@wafflestudio.com", "")
+                        every { userRepository.findUserById(1) } returns temp
+
+                        val response = userService.patchMe(1, PatchRequest(username, email))
+
+                        assertThat(response).extracting("userId").isEqualTo("fooId")
+                        assertThat(response).extracting("username").isEqualTo(username ?: "foo")
+                        assertThat(response).extracting("email").isEqualTo(email ?: "foo@wafflestudio.com")
+                    }
+                }
+            }
+        }
+
+        this.describe("deleteMe 호출 될 때") {
+            val temp = User("", "", "", "")
+            every { userRepository.findUserById(1) } returns temp
+
+            context("현재 로그인 된 유저 아이디를 넣으면") {
+                it("유저의 isDeleted 필드는 true 가 된다") {
+                    assertThat(temp.isDeleted).isFalse()
+
+                    withContext(Dispatchers.IO) {
+                        userService.deleteMe(1)
+                    }
+
+                    assertThat(temp.isDeleted).isTrue()
+                }
+            }
+        }
+
+        this.describe("getUserWithId 호출 될 때") {
+            context("존재하는 유저의 아이디를 넣으면") {
+                every { userRepository.findUserById(1000) } returns user
+
+                it("유저의 SimpleResponse 가 반환된다") {
+                    val response = withContext(Dispatchers.IO) {
+                        userService.getUserWithId(1000)
+                    }
+
+                    assertThat(response).extracting("userId").isEqualTo("fooId")
+                    assertThat(response).extracting("username").isEqualTo("foo")
+                    assertThat(response).extracting("email").isEqualTo("foo@wafflestudio.com")
+                }
+            }
+
+            context("존재하지 않는 유저의 아이디를 넣으면") {
+                every { userRepository.findUserById(1000) } returns null
+
+                it("UserNotFoundException 예외를 던진다") {
+                    assertThrows<UserNotFoundException> { userService.getUserWithId(1000) }
+                }
+            }
+
+            context("존재하지만 탈퇴한 유저의 아이디를 넣으면") {
+                val temp = User("", "", "", "")
+                temp.isDeleted = true
+                every { userRepository.findUserById(1000) } returns temp
+
+                it("UserNotFoundException 예외를 던진다") {
+                    assertThrows<UserNotFoundException> { userService.getUserWithId(1000) }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/global/security/AuthDescribeSpec.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/global/security/AuthDescribeSpec.kt
@@ -9,6 +9,11 @@ import com.wafflestudio.webgam.RestDocsUtils.Companion.requestBody
 import com.wafflestudio.webgam.STRING
 import com.wafflestudio.webgam.domain.user.model.User
 import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.INVALID_FIELD
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.NO_REFRESH_TOKEN
+import com.wafflestudio.webgam.global.common.exception.ErrorType.Conflict.DUPLICATE_USER_IDENTIFIER
+import com.wafflestudio.webgam.global.common.exception.ErrorType.Forbidden.NO_ACCESS
+import com.wafflestudio.webgam.global.common.exception.ErrorType.Unauthorized.*
 import com.wafflestudio.webgam.global.security.dto.AuthDto.*
 import com.wafflestudio.webgam.global.security.jwt.JwtProvider
 import com.wafflestudio.webgam.global.security.model.WebgamRoles.USER
@@ -97,14 +102,14 @@ internal class AuthDescribeSpec(
             }
 
             context("필요항목을 누락하면") {
-                it("400 Bad Request, 에러코드 1") {
+                it("400 Bad Request, 에러코드 ${INVALID_FIELD.code()}") {
                     mockMvc.perform(
                         post("/signup")
                             .contentType(APPLICATION_JSON)
                             .content(gson.toJson(invalidSignupRequest))
                     ).andDo(document("signup/400-0001", getDocumentResponse())
                     ).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(1))
+                    ).andExpect(jsonPath("$.error_code", `is`(INVALID_FIELD.code()))
                     ).andDo(print())
                 }
             }
@@ -114,14 +119,14 @@ internal class AuthDescribeSpec(
                     userRepository.save(User("duplicate-id", "foo", "unqiue@wafflestudio.com", "password"))
                 }
 
-                it("409 Conflict, 에러코드 9001") {
+                it("409 Conflict, 에러코드 ${DUPLICATE_USER_IDENTIFIER.code()}") {
                     mockMvc.perform(
                         post("/signup")
                             .contentType(APPLICATION_JSON)
                             .content(gson.toJson(duplicateSignupRequest))
                     ).andDo(document("signup/409-9001", getDocumentResponse())
                     ).andExpect(status().isConflict
-                    ).andExpect(jsonPath("$.error_code", `is`(9001))
+                    ).andExpect(jsonPath("$.error_code", `is`(DUPLICATE_USER_IDENTIFIER.code()))
                     ).andDo(print())
                 }
             }
@@ -151,7 +156,7 @@ internal class AuthDescribeSpec(
             }
 
             context("실패하면") {
-                it("401 Unauthorized, 에러코드 1001") {
+                it("401 Unauthorized, 에러코드 ${LOGIN_FAIL.code()}") {
                     mockMvc.perform(
                         post("/login")
                             .contentType(APPLICATION_JSON)
@@ -160,7 +165,7 @@ internal class AuthDescribeSpec(
                         getDocumentRequest(),
                         getDocumentResponse())
                     ).andExpect(status().isUnauthorized
-                    ).andExpect(jsonPath("$.error_code", `is`(1001))
+                    ).andExpect(jsonPath("$.error_code", `is`(LOGIN_FAIL.code()))
                     ).andDo(print())
                 }
             }
@@ -202,36 +207,36 @@ internal class AuthDescribeSpec(
             }
 
             context("JWT Refresh 토큰이 없을 때") {
-                it("400 Bad Request, 에러코드 2") {
+                it("400 Bad Request, 에러코드 ${NO_REFRESH_TOKEN.code()}") {
                     mockMvc.perform(
                         post("/refresh")
                     ).andDo(document("refresh/400-0002-no-cookie", getDocumentResponse())
                     ).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(2))
+                    ).andExpect(jsonPath("$.error_code", `is`(NO_REFRESH_TOKEN.code()))
                     ).andDo(print())
                 }
             }
 
             context("쿠키에 다른 값이 들어있을 때") {
-                it("400 Bad Request, 에러코드 2") {
+                it("400 Bad Request, 에러코드 ${NO_REFRESH_TOKEN.code()}") {
                     mockMvc.perform(
                         post("/refresh")
                             .cookie(Cookie("something", "something"))
                     ).andDo(document("refresh/400-0002-no-token", getDocumentResponse())
                     ).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(2))
+                    ).andExpect(jsonPath("$.error_code", `is`(NO_REFRESH_TOKEN.code()))
                     ).andDo(print())
                 }
             }
 
             context("JWT Refresh 토큰이 유효하지 않을 때") {
-                it("401 Unauthorized, 에러코드 1002") {
+                it("401 Unauthorized, 에러코드 ${INVALID_JWT.code()}") {
                     mockMvc.perform(
                         post("/refresh")
                             .cookie(Cookie("refresh_token", "something"))
                     ).andDo(document("refresh/401-1002", getDocumentResponse())
                     ).andExpect(status().isUnauthorized
-                    ).andExpect(jsonPath("$.error_code", `is`(1002))
+                    ).andExpect(jsonPath("$.error_code", `is`(INVALID_JWT.code()))
                     ).andDo(print())
                 }
             }
@@ -270,27 +275,27 @@ internal class AuthDescribeSpec(
             }
 
             context("토큰이 없으면") {
-                it("401 Unauthorized, 에러코드 1000") {
+                it("401 Unauthorized, 에러코드 ${DEFAULT.code()}") {
                     mockMvc.perform(
                         get("/auth-ping")
                     ).andDo(document(
                         "auth-ping/401-1000",
                         getDocumentResponse())
                     ).andExpect(status().isUnauthorized
-                    ).andExpect(jsonPath("$.error_code", `is`(1000))
+                    ).andExpect(jsonPath("$.error_code", `is`(DEFAULT.code()))
                     ).andDo(print())
                 }
             }
 
             context("토큰이 유효하지 않으면") {
-                it("401 Unauthorized, 에러코드 1002") {
+                it("401 Unauthorized, 에러코드 ${INVALID_JWT.code()}") {
                     mockMvc.perform(
                         get("/auth-ping").header("Authorization", "invalid")
                     ).andDo(document(
                         "auth-ping/401-1002",
                         getDocumentResponse())
                     ).andExpect(status().isUnauthorized
-                    ).andExpect(jsonPath("$.error_code", `is`(1002))
+                    ).andExpect(jsonPath("$.error_code", `is`(INVALID_JWT.code()))
                     ).andDo(print())
                 }
             }
@@ -300,7 +305,7 @@ internal class AuthDescribeSpec(
                     userRepository.save(User("fooId", "", "", ""))
                 }
 
-                it("403 Forbidden, 에러코드 3001") {
+                it("403 Forbidden, 에러코드 ${NO_ACCESS.code()}") {
                     val accessToken = jwtProvider.generateToken("fooId", USER).first
 
                     mockMvc.perform(
@@ -309,7 +314,7 @@ internal class AuthDescribeSpec(
                         "auth-ping/403-3001",
                         getDocumentResponse())
                     ).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", `is`(3001))
+                    ).andExpect(jsonPath("$.error_code", `is`(NO_ACCESS.code()))
                     ).andDo(print())
                 }
             }

--- a/src/test/kotlin/com/wafflestudio/webgam/global/security/AuthDescribeSpec.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/global/security/AuthDescribeSpec.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.webgam.global.security
 
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.GsonBuilder
+import com.wafflestudio.webgam.BOOLEAN
 import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentRequest
 import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentResponse
 import com.wafflestudio.webgam.RestDocsUtils.Companion.requestBody
@@ -143,6 +144,7 @@ internal class AuthDescribeSpec(
                         requestBody(
                             "user_id" type STRING means "로그인 할 유저 아이디",
                             "password" type STRING means "로그인 비밀번호",
+                            "auto" type BOOLEAN means "자동 로그인 여부" withDefaultValue "false" isOptional true
                         ))
                     ).andExpect(status().isOk).andDo(print())
                 }
@@ -156,13 +158,22 @@ internal class AuthDescribeSpec(
                             .content(gson.toJson(invalidLoginRequest))
                     ).andDo(document("login/401-1001",
                         getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestBody(
-                            "user_id" type STRING means "로그인 할 유저 아이디",
-                            "password" type STRING means "로그인 비밀번호",
-                        ))
+                        getDocumentResponse())
                     ).andExpect(status().isUnauthorized
                     ).andExpect(jsonPath("$.error_code", `is`(1001))
+                    ).andDo(print())
+                }
+            }
+        }
+
+        this.describe("로그아웃할 때") {
+            context("성공하면") {
+                it("200 OK") {
+                    mockMvc.perform(post("/logout")
+                    ).andDo(document("logout/200",
+                        getDocumentRequest(),
+                        getDocumentResponse())
+                    ).andExpect(status().isOk
                     ).andDo(print())
                 }
             }

--- a/src/test/kotlin/com/wafflestudio/webgam/global/security/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/global/security/controller/AuthControllerTest.kt
@@ -5,6 +5,9 @@ import com.google.gson.GsonBuilder
 import com.ninjasquad.springmockk.MockkBean
 import com.wafflestudio.webgam.domain.user.dto.UserDto.SimpleResponse
 import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.INVALID_FIELD
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.NO_REFRESH_TOKEN
+import com.wafflestudio.webgam.global.common.exception.ErrorType.Unauthorized.INVALID_JWT
 import com.wafflestudio.webgam.global.security.dto.AuthDto.Response
 import com.wafflestudio.webgam.global.security.dto.JwtDto
 import com.wafflestudio.webgam.global.security.exception.InvalidJwtException
@@ -78,7 +81,7 @@ class AuthControllerTest(
             }
 
             context("아이디를 누락하거나 공백, NULL 이면") {
-                it("400 Bad Request, 에러코드 1") {
+                it("400 Bad Request, 에러코드 ${INVALID_FIELD.code()}") {
                     val userIds = mutableListOf("omit", "", "    ", null)
                     userIds.forAll {
                         val request = HashMap<String, String?>()
@@ -91,14 +94,14 @@ class AuthControllerTest(
                             content = gson.toJson(request)
                         }.andExpect {
                             status { isBadRequest() }
-                            jsonPath("$.error_code", `is`(1))
+                            jsonPath("$.error_code", `is`(INVALID_FIELD.code()))
                         }
                     }
                 }
             }
 
             context("유저네임을 누락하거나 공백, NULL 이면") {
-                it("400 Bad Request, 에러코드 1") {
+                it("400 Bad Request, 에러코드 ${INVALID_FIELD.code()}") {
                     val usernames = mutableListOf("omit", "", "    ", null)
                     usernames.forAll {
                         val request = HashMap<String, String?>()
@@ -111,14 +114,14 @@ class AuthControllerTest(
                             content = gson.toJson(request)
                         }.andExpect {
                             status { isBadRequest() }
-                            jsonPath("$.error_code", `is`(1))
+                            jsonPath("$.error_code", `is`(INVALID_FIELD.code()))
                         }
                     }
                 }
             }
 
             context("이메일이 누락하거나 공백, NULL, 잘못된 형식이면") {
-                it("400 Bad Request, 에러코드 1") {
+                it("400 Bad Request, 에러코드 ${INVALID_FIELD.code()}") {
                     val emails = mutableListOf("omit", "", "    ", null, "email", "@")
                     emails.forAll {
                         val request = HashMap<String, String?>()
@@ -131,7 +134,7 @@ class AuthControllerTest(
                             content = gson.toJson(request)
                         }.andExpect {
                             status { isBadRequest() }
-                            jsonPath("$.error_code", `is`(1))
+                            jsonPath("$.error_code", `is`(INVALID_FIELD.code()))
                         }
                     }
                 }
@@ -155,7 +158,7 @@ class AuthControllerTest(
             }
 
             context("비밀번호를 누락하거나 공백, NULL 이면") {
-                it("400 Bad Request, 에러코드 1") {
+                it("400 Bad Request, 에러코드 ${INVALID_FIELD.code()}") {
                     val passwords = mutableListOf("omit", "", "    ", null)
                     passwords.forAll {
                         val request = HashMap<String, String?>()
@@ -168,7 +171,7 @@ class AuthControllerTest(
                             content = gson.toJson(request)
                         }.andExpect {
                             status { isBadRequest() }
-                            jsonPath("$.error_code", `is`(1))
+                            jsonPath("$.error_code", `is`(INVALID_FIELD.code()))
                         }
                     }
                 }
@@ -240,7 +243,7 @@ class AuthControllerTest(
             }
 
             context("아이디를 누락하거나 공백, NULL 이면") {
-                it("400 Bad Request, 에러코드 1") {
+                it("400 Bad Request, 에러코드 ${INVALID_FIELD.code()}") {
                     val userIds = mutableListOf("omit", "", "    ", null)
                     userIds.forAll {
                         val request = HashMap<String, String?>()
@@ -251,14 +254,14 @@ class AuthControllerTest(
                             content = gson.toJson(request)
                         }.andExpect {
                             status { isBadRequest() }
-                            jsonPath("$.error_code", `is`(1))
+                            jsonPath("$.error_code", `is`(INVALID_FIELD.code()))
                         }
                     }
                 }
             }
 
             context("비밀번호가 누락하거나 공백, NULL 이면") {
-                it("400 Bad Request, 에러코드 1") {
+                it("400 Bad Request, 에러코드 ${INVALID_FIELD.code()}") {
                     val passwords = mutableListOf("omit", "", "    ", null)
                     passwords.forAll {
                         val request = HashMap<String, String?>()
@@ -269,7 +272,7 @@ class AuthControllerTest(
                             content = gson.toJson(request)
                         }.andExpect {
                             status { isBadRequest() }
-                            jsonPath("$.error_code", `is`(1))
+                            jsonPath("$.error_code", `is`(INVALID_FIELD.code()))
                         }
                     }
                 }
@@ -288,10 +291,10 @@ class AuthControllerTest(
             }
 
             context("refreshToken 쿠키가 없으면") {
-                it("400 Bad Request, 에러코드 2") {
+                it("400 Bad Request, 에러코드 ${NO_REFRESH_TOKEN.code()}") {
                     mockMvc.post("/refresh").andDo { print() }.andExpect {
                         status { isBadRequest() }
-                        jsonPath("$.error_code", `is`(2))
+                        jsonPath("$.error_code", `is`(NO_REFRESH_TOKEN.code()))
                     }
                 }
             }
@@ -299,12 +302,12 @@ class AuthControllerTest(
             context("유효하지 않은 refreshToken 쿠키가 있으면") {
                 every { authService.refreshToken(any()) } throws InvalidJwtException("message")
 
-                it("401 Unauthorized, 에러코드 1002") {
+                it("401 Unauthorized, 에러코드 ${INVALID_JWT.code()}") {
                     mockMvc.post("/refresh") {
                         cookie(Cookie("refresh_token", "dummy_valid_token"))
                     }.andExpect {
                         status { isUnauthorized() }
-                        jsonPath("$.error_code", `is`(1002))
+                        jsonPath("$.error_code", `is`(INVALID_JWT.code()))
                     }
                 }
             }


### PR DESCRIPTION
- 자동 로그인, secure 쿠키를 없애는 로그아웃 API도 추가하였습니다
- 기존 API와 크게 달라진 부분은 없으나 Error Response가 조금 수정되었습니다.
- 내 정보 수정하기의 경우, 기존에는 `PUT`이었지만 `PATCH`가 조금 더 적합하다고 생각되어 변경하였습니다
- `@NullableNotBlank` 커스텀 어노테이션을 만들었으니, patch API 개발하실 때 사용하면 편리하실겁니다. 자세한 사용은 코드 참조해주세요
- 기존 Documentation이 `index.adoc` 파일 하나로 유지되던 것을 API 도메인 별로 분리하였습니다.

`ErrorCode`가 하다보면 많이 겹쳐서 conflict 날 것 같은데 좋은 방법이 없을까요?