### PR TITLE
Object CRUD API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,10 @@ plugins {
 	id("org.springframework.boot") version "3.0.1"
 	id("io.spring.dependency-management") version "1.1.0"
 	id("org.asciidoctor.jvm.convert") version "3.3.2"
-	kotlin("jvm") version "1.7.22"
-	kotlin("plugin.spring") version "1.7.22"
-	kotlin("plugin.jpa") version "1.7.22"
+	kotlin("jvm") version "1.8.0"
+	kotlin("plugin.spring") version "1.8.0"
+	kotlin("plugin.jpa") version "1.8.0"
+	kotlin("kapt") version "1.8.0"
 }
 
 group = "com.wafflestudio"
@@ -31,6 +32,8 @@ dependencies {
 	implementation("com.google.code.gson:gson:2.10.1")
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
 	implementation("io.hypersistence:hypersistence-utils-hibernate-60:3.0.1")
+	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
 	runtimeOnly("com.mysql:mysql-connector-j:8.0.31")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-gson:0.11.5")

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -47,3 +47,4 @@ include::{snippets}/auth-ping/403-3001/http-response.adoc[]
 
 include::auth.adoc[]
 include::user.adoc[]
+include::object.adoc[]

--- a/src/docs/asciidoc/object.adoc
+++ b/src/docs/asciidoc/object.adoc
@@ -1,0 +1,75 @@
+[[Object]]
+== Object API
+=== 프로젝트 내 모든 오브젝트 조회하기
+====
+.Request
+include::{snippets}/get-project-objects/200/http-request.adoc[]
+.Query Parameter
+include::{snippets}/get-project-objects/200/query-parameters.adoc[]
+.Response
+include::{snippets}/get-project-objects/200/http-response.adoc[]
+.Error Response
+include::{snippets}/get-project-objects/400-0/http-response.adoc[]
+include::{snippets}/get-project-objects/403-0/http-response.adoc[]
+include::{snippets}/get-project-objects/404-0/http-response.adoc[]
+====
+
+=== 오브젝트 생성하기
+====
+.Request
+include::{snippets}/create-object/200/http-request.adoc[]
+.Request Body
+include::{snippets}/create-object/200/request-fields.adoc[]
+.Response
+include::{snippets}/create-object/200/http-response.adoc[]
+.Error Response
+include::{snippets}/create-object/400-0/http-response.adoc[]
+include::{snippets}/create-object/400-1/http-response.adoc[]
+include::{snippets}/create-object/403-0/http-response.adoc[]
+include::{snippets}/create-object/404-0/http-response.adoc[]
+====
+
+=== 오브젝트 조회하기
+====
+.Request
+include::{snippets}/get-object/200/http-request.adoc[]
+.Path Parameter
+include::{snippets}/get-object/200/path-parameters.adoc[]
+.Response
+include::{snippets}/get-object/200/http-response.adoc[]
+.Error Response
+include::{snippets}/get-object/400-0/http-response.adoc[]
+include::{snippets}/get-object/403-0/http-response.adoc[]
+include::{snippets}/get-object/404-0/http-response.adoc[]
+====
+
+=== 오브젝트 수정하기
+====
+.Request
+include::{snippets}/patch-object/200/http-request.adoc[]
+.Path Parameter
+include::{snippets}/patch-object/200/path-parameters.adoc[]
+.Request Body
+include::{snippets}/patch-object/200/request-fields.adoc[]
+.Response
+include::{snippets}/patch-object/200/http-response.adoc[]
+.Error Response
+include::{snippets}/patch-object/400-0/http-response.adoc[]
+include::{snippets}/patch-object/400-1/http-response.adoc[]
+include::{snippets}/patch-object/403-0/http-response.adoc[]
+include::{snippets}/patch-object/404-0/http-response.adoc[]
+====
+
+=== 오브젝트 삭제하기
+====
+.Request
+include::{snippets}/delete-object/200/http-request.adoc[]
+.Path Parameter
+include::{snippets}/delete-object/200/path-parameters.adoc[]
+.Response
+include::{snippets}/delete-object/200/http-response.adoc[]
+.Error Response
+include::{snippets}/delete-object/400-0/http-response.adoc[]
+include::{snippets}/delete-object/403-0/http-response.adoc[]
+include::{snippets}/delete-object/404-0/http-response.adoc[]
+====

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/controller/PageObjectController.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/controller/PageObjectController.kt
@@ -1,0 +1,61 @@
+package com.wafflestudio.webgam.domain.`object`.controller
+
+import com.wafflestudio.webgam.domain.`object`.dto.PageObjectDto.*
+import com.wafflestudio.webgam.domain.`object`.service.PageObjectService
+import com.wafflestudio.webgam.global.common.dto.ListResponse
+import com.wafflestudio.webgam.global.security.CurrentUser
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/objects")
+class PageObjectController(
+    private val projectObjectService: PageObjectService,
+) {
+    @GetMapping
+    fun listObjects(
+        @CurrentUser myId: Long,
+        @RequestParam("project-id") @NotNull @Positive projectId: Long?,
+    ): ResponseEntity<ListResponse<DetailedResponse>> {
+        return ResponseEntity.ok(projectObjectService.listProjectObjects(myId, projectId!!))
+    }
+
+    @PostMapping
+    fun createObject(
+        @CurrentUser myId: Long,
+        @RequestBody @Valid request: CreateRequest,
+    ): ResponseEntity<SimpleResponse> {
+        return ResponseEntity.ok(projectObjectService.createObject(myId, request))
+    }
+
+    @GetMapping("/{id}")
+    fun getObject(
+        @CurrentUser myId: Long,
+        @PathVariable("id") @Positive objectId: Long,
+    ): ResponseEntity<DetailedResponse> {
+        return ResponseEntity.ok(projectObjectService.getObject(myId, objectId))
+    }
+
+    @PatchMapping("/{id}")
+    fun patchObject(
+        @CurrentUser myId: Long,
+        @PathVariable("id") @Positive objectId: Long,
+        @RequestBody @Valid request: PatchRequest,
+    ): ResponseEntity<DetailedResponse> {
+        return ResponseEntity.ok(projectObjectService.modifyObject(myId, objectId, request))
+    }
+
+    @DeleteMapping("/{id}")
+    fun deleteObject(
+        @CurrentUser myId: Long,
+        @PathVariable("id") @Positive objectId: Long,
+    ): ResponseEntity<Any> {
+        projectObjectService.deleteObject(myId, objectId)
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/dto/PageObjectDto.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/dto/PageObjectDto.kt
@@ -6,28 +6,48 @@ import com.wafflestudio.webgam.domain.`object`.model.PageObjectType
 import com.wafflestudio.webgam.global.common.dto.TimeTraceEntityDto
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
 import org.hibernate.validator.constraints.URL
 import java.time.LocalDateTime
 
 class PageObjectDto {
     data class CreateRequest(
-        @field:NotNull
+        @field:[NotNull Positive]
         val pageId: Long?,
         @field:NotBlank
         val name: String?,
         val type: PageObjectType = PageObjectType.DEFAULT,
-        @field:NotNull
+        @field:[NotNull Positive]
         val width: Int?,
-        @field:NotNull
+        @field:[NotNull Positive]
         val height: Int?,
         @field:NotNull
         val xPosition: Int?,
         @field:NotNull
         val yPosition: Int?,
-        @field:NotNull
+        @field:[NotNull PositiveOrZero]
         val zIndex: Int?,
         /* Optional */
         val textContent: String?,
+        @field:Positive
+        val fontSize: Int?,
+        @field:URL
+        val imageSource: String?,
+    )
+
+    data class PatchRequest(
+        val type: PageObjectType?,
+        @field:Positive
+        val width: Int?,
+        @field:Positive
+        val height: Int?,
+        val xPosition: Int?,
+        val yPosition: Int?,
+        @field:PositiveOrZero
+        val zIndex: Int?,
+        val textContent: String?,
+        @field:Positive
         val fontSize: Int?,
         @field:URL
         val imageSource: String?,

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/exception/NonAccessiblePageObjectException.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/exception/NonAccessiblePageObjectException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.`object`.exception
+
+import com.wafflestudio.webgam.global.common.exception.ErrorType.Forbidden.NON_ACCESSIBLE_PAGE_OBJECT
+import com.wafflestudio.webgam.global.common.exception.WebgamException
+
+class NonAccessiblePageObjectException(id: Long): WebgamException.Forbidden(NON_ACCESSIBLE_PAGE_OBJECT,
+    "You have no access to Object with id $id")

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/exception/PageObjectNotFoundException.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/exception/PageObjectNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.`object`.exception
+
+import com.wafflestudio.webgam.global.common.exception.ErrorType.NotFound.PAGE_OBJECT_NOT_FOUND
+import com.wafflestudio.webgam.global.common.exception.WebgamException
+
+class PageObjectNotFoundException(id: Long): WebgamException.NotFound(PAGE_OBJECT_NOT_FOUND,
+    "Object with id $id does not exists.")

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/model/PageObject.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/model/PageObject.kt
@@ -60,4 +60,9 @@ class PageObject(
     ) {
         page.objects.add(this)
     }
+
+    override fun delete() {
+        isDeleted = true
+        event?.delete()
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepository.kt
@@ -1,7 +1,9 @@
-package com.wafflestudio.webgam.domain.`object`.repository;
+package com.wafflestudio.webgam.domain.`object`.repository
 
 import com.wafflestudio.webgam.domain.`object`.model.PageObject
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
-interface PageObjectRepository : JpaRepository<PageObject, Long> {
+@Repository
+interface PageObjectRepository : JpaRepository<PageObject, Long>, PageObjectRepositoryCustom {
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepositoryCustom.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.webgam.domain.`object`.repository
+
+import com.wafflestudio.webgam.domain.`object`.model.PageObject
+
+interface PageObjectRepositoryCustom {
+    fun findUndeletedPageObjectById(id: Long): PageObject?
+    fun findAllUndeletedPageObjectsInProject(projectId: Long): List<PageObject>
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepositoryImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepositoryImpl.kt
@@ -1,0 +1,44 @@
+package com.wafflestudio.webgam.domain.`object`.repository
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.webgam.domain.event.model.QObjectEvent.objectEvent
+import com.wafflestudio.webgam.domain.`object`.model.PageObject
+import com.wafflestudio.webgam.domain.`object`.model.QPageObject.pageObject
+import com.wafflestudio.webgam.domain.page.model.QProjectPage.projectPage
+import com.wafflestudio.webgam.domain.project.model.QProject.project
+import com.wafflestudio.webgam.domain.user.model.QUser.user
+import org.springframework.stereotype.Repository
+
+@Repository
+class PageObjectRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : PageObjectRepositoryCustom {
+
+    fun id(id: Long): BooleanExpression = pageObject.id.eq(id)
+    fun undeletedPageObject(): BooleanExpression = pageObject.isDeleted.isFalse
+    fun undeletedProjectPage(): BooleanExpression = projectPage.isDeleted.isFalse
+    fun undeletedProject(): BooleanExpression = project.isDeleted.isFalse
+    fun undeletedUser(): BooleanExpression = user.isDeleted.isFalse
+
+    override fun findUndeletedPageObjectById(id: Long): PageObject? = jpaQueryFactory
+        .select(pageObject)
+        .from(pageObject)
+        .leftJoin(pageObject.page, projectPage).fetchJoin()
+        .leftJoin(pageObject.event, objectEvent).fetchJoin()
+        .leftJoin(projectPage.project, project).fetchJoin()
+        .leftJoin(project.owner, user).fetchJoin()
+        .where(id(id), undeletedPageObject(), undeletedProjectPage(), undeletedProject(), undeletedUser())
+        .fetchOne()
+
+    override fun findAllUndeletedPageObjectsInProject(projectId: Long): List<PageObject> = jpaQueryFactory
+        .select(pageObject)
+        .from(pageObject)
+        .leftJoin(pageObject.page, projectPage).fetchJoin()
+        .leftJoin(pageObject.event, objectEvent).fetchJoin()
+        .leftJoin(projectPage.project, project).fetchJoin()
+        .leftJoin(project.owner, user).fetchJoin()
+        .where(project.id.eq(projectId), undeletedPageObject(), undeletedProjectPage(), undeletedProject(), undeletedUser())
+        .fetch()
+
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/service/PageObjectService.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/service/PageObjectService.kt
@@ -1,0 +1,79 @@
+package com.wafflestudio.webgam.domain.`object`.service
+
+import com.wafflestudio.webgam.domain.`object`.dto.PageObjectDto.*
+import com.wafflestudio.webgam.domain.`object`.exception.NonAccessiblePageObjectException
+import com.wafflestudio.webgam.domain.`object`.exception.PageObjectNotFoundException
+import com.wafflestudio.webgam.domain.`object`.model.PageObject
+import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
+import com.wafflestudio.webgam.domain.page.exception.NonAccessibleProjectPageException
+import com.wafflestudio.webgam.domain.page.exception.ProjectPageNotFoundException
+import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.project.exception.NonAccessibleProjectException
+import com.wafflestudio.webgam.domain.project.exception.ProjectNotFoundException
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import com.wafflestudio.webgam.global.common.dto.ListResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class PageObjectService(
+    private val projectRepository: ProjectRepository,
+    private val projectPageRepository: ProjectPageRepository,
+    private val pageObjectRepository: PageObjectRepository,
+) {
+    fun listProjectObjects(myId: Long, projectId: Long): ListResponse<DetailedResponse> {
+        val project = projectRepository.findUndeletedProjectById(projectId) ?: throw ProjectNotFoundException(projectId)
+        if (!project.isAccessibleTo(myId)) throw NonAccessibleProjectException(projectId)
+
+        val objects = pageObjectRepository.findAllUndeletedPageObjectsInProject(projectId)
+            .filter { it.isAccessibleTo(myId) }
+            .map { DetailedResponse(it) }
+            .toList()
+
+        return ListResponse(objects)
+    }
+
+    fun getObject(myId: Long, objectId: Long): DetailedResponse {
+        val pageObject = pageObjectRepository.findUndeletedPageObjectById(objectId) ?: throw PageObjectNotFoundException(objectId)
+        if (!pageObject.isAccessibleTo(myId)) throw NonAccessiblePageObjectException(objectId)
+
+        return DetailedResponse(pageObject)
+    }
+
+    @Transactional
+    fun createObject(myId: Long, request: CreateRequest): SimpleResponse {
+        val page = projectPageRepository.findUndeletedProjectPageById(request.pageId!!) ?: throw ProjectPageNotFoundException(request.pageId)
+        if (!page.isAccessibleTo(myId)) throw NonAccessibleProjectPageException(request.pageId)
+
+        val pageObject = pageObjectRepository.save(PageObject(page, request))
+
+        return SimpleResponse(pageObject)
+    }
+
+    @Transactional
+    fun modifyObject(myId: Long, objectId: Long, request: PatchRequest): DetailedResponse {
+        val pageObject = pageObjectRepository.findUndeletedPageObjectById(objectId) ?: throw PageObjectNotFoundException(objectId)
+        if (!pageObject.isAccessibleTo(myId)) throw NonAccessiblePageObjectException(objectId)
+
+        request.type ?.let { pageObject.type = request.type }
+        request.width ?.let { pageObject.width = request.width }
+        request.height ?.let { pageObject.height = request.height }
+        request.xPosition ?.let { pageObject.xPosition = request.xPosition }
+        request.yPosition ?.let { pageObject.yPosition = request.yPosition }
+        request.zIndex ?.let { pageObject.zIndex = request.zIndex }
+        request.textContent ?.let { pageObject.textContent = request.textContent }
+        request.fontSize ?.let { pageObject.fontSize = request.fontSize }
+        request.imageSource ?.let { pageObject.imageSource = request.imageSource }
+
+        return DetailedResponse(pageObject)
+    }
+
+    @Transactional
+    fun deleteObject(myId: Long, objectId: Long) {
+        val pageObject = pageObjectRepository.findUndeletedPageObjectById(objectId) ?: throw PageObjectNotFoundException(objectId)
+        if (!pageObject.isAccessibleTo(myId)) throw NonAccessiblePageObjectException(objectId)
+
+        pageObject.delete()
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/exception/NonAccessibleProjectPageException.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/exception/NonAccessibleProjectPageException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.page.exception
+
+import com.wafflestudio.webgam.global.common.exception.ErrorType
+import com.wafflestudio.webgam.global.common.exception.WebgamException
+
+class NonAccessibleProjectPageException(id: Long): WebgamException.Forbidden(ErrorType.Forbidden.NON_ACCESSIBLE_PROJECT_PAGE,
+    "You have no access to Page with id $id")

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/exception/ProjectPageNotFoundException.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/exception/ProjectPageNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.page.exception
+
+import com.wafflestudio.webgam.global.common.exception.ErrorType
+import com.wafflestudio.webgam.global.common.exception.WebgamException
+
+class ProjectPageNotFoundException(id: Long): WebgamException.NotFound(ErrorType.NotFound.PROJECT_PAGE_NOT_FOUND,
+    "Page with id $id does not exists.")

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepository.kt
@@ -1,7 +1,7 @@
-package com.wafflestudio.webgam.domain.page.repository;
+package com.wafflestudio.webgam.domain.page.repository
 
 import com.wafflestudio.webgam.domain.page.model.ProjectPage
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ProjectPageRepository : JpaRepository<ProjectPage, Long> {
+interface ProjectPageRepository : JpaRepository<ProjectPage, Long>, ProjectPageRepositoryCustom {
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepositoryCustom.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepositoryCustom.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.page.repository
+
+import com.wafflestudio.webgam.domain.page.model.ProjectPage
+
+interface ProjectPageRepositoryCustom {
+    fun findUndeletedProjectPageById(id: Long): ProjectPage?
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepositoryImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.wafflestudio.webgam.domain.page.repository
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.webgam.domain.page.model.ProjectPage
+import com.wafflestudio.webgam.domain.page.model.QProjectPage.projectPage
+import com.wafflestudio.webgam.domain.project.model.QProject.project
+import com.wafflestudio.webgam.domain.user.model.QUser.user
+import org.springframework.stereotype.Repository
+
+@Repository
+class ProjectPageRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+): ProjectPageRepositoryCustom {
+
+    fun id(id: Long): BooleanExpression = projectPage.id.eq(id)
+    fun undeletedProjectPage(): BooleanExpression = projectPage.isDeleted.isFalse
+    fun undeletedProject(): BooleanExpression = project.isDeleted.isFalse
+    fun undeletedUser(): BooleanExpression = user.isDeleted.isFalse
+
+    override fun findUndeletedProjectPageById(id: Long): ProjectPage? = jpaQueryFactory
+        .select(projectPage)
+        .from(projectPage)
+        .leftJoin(projectPage.project, project).fetchJoin()
+        .leftJoin(project.owner, user).fetchJoin()
+        .where(id(id), undeletedProjectPage(), undeletedProject(), undeletedUser())
+        .fetchOne()
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/exception/NonAccessibleProjectException.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/exception/NonAccessibleProjectException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.project.exception
+
+import com.wafflestudio.webgam.global.common.exception.ErrorType
+import com.wafflestudio.webgam.global.common.exception.WebgamException
+
+class NonAccessibleProjectException(id: Long): WebgamException.Forbidden(ErrorType.Forbidden.NON_ACCESSIBLE_PROJECT,
+    "You have no access to Project with id $id")

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/exception/ProjectNotFoundException.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/exception/ProjectNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.project.exception
+
+import com.wafflestudio.webgam.global.common.exception.ErrorType
+import com.wafflestudio.webgam.global.common.exception.WebgamException
+
+class ProjectNotFoundException(id: Long): WebgamException.NotFound(ErrorType.NotFound.PROJECT_NOT_FOUND,
+    "Project with id $id does not exists.")

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepository.kt
@@ -1,7 +1,7 @@
-package com.wafflestudio.webgam.domain.project.repository;
+package com.wafflestudio.webgam.domain.project.repository
 
 import com.wafflestudio.webgam.domain.project.model.Project
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ProjectRepository : JpaRepository<Project, Long> {
+interface ProjectRepository : JpaRepository<Project, Long>, ProjectRepositoryCustom {
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryCustom.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryCustom.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.project.repository
+
+import com.wafflestudio.webgam.domain.project.model.Project
+
+interface ProjectRepositoryCustom {
+    fun findUndeletedProjectById(id: Long): Project?
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.wafflestudio.webgam.domain.project.repository
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.project.model.QProject.project
+import com.wafflestudio.webgam.domain.user.model.QUser.user
+import org.springframework.stereotype.Repository
+
+@Repository
+class ProjectRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+): ProjectRepositoryCustom {
+
+    fun id(id: Long): BooleanExpression = project.id.eq(id)
+    fun undeletedProject(): BooleanExpression = project.isDeleted.isFalse
+    fun undeletedUser(): BooleanExpression = user.isDeleted.isFalse
+
+    override fun findUndeletedProjectById(id: Long): Project? = jpaQueryFactory
+        .select(project)
+        .from(project)
+        .leftJoin(project.owner, user).fetchJoin()
+        .where(id(id), undeletedProject(), undeletedUser())
+        .fetchOne()
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/dto/ListResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/dto/ListResponse.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.webgam.global.common.dto
+
+data class ListResponse<T: Any> (
+    val count: Int,
+    val data: List<T>,
+) {
+    constructor(list: List<T>): this(
+        count = list.size,
+        data = list
+    )
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/ErrorType.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/ErrorType.kt
@@ -7,6 +7,7 @@ enum class ErrorType {
         INVALID_FIELD(1),
         NO_REFRESH_TOKEN(2),
         CONSTRAINT_VIOLATION(3),
+        JSON_PARSE_ERROR(4),
         ;
 
         override fun code(): Int {
@@ -28,6 +29,10 @@ enum class ErrorType {
     enum class Forbidden(private val code: Int): Error {
         DEFAULT(3000),
         NO_ACCESS(3001),
+        NON_ACCESSIBLE_PROJECT(3100),
+        NON_ACCESSIBLE_PROJECT_PAGE(3200),
+        NON_ACCESSIBLE_PAGE_OBJECT(3300),
+        NON_ACCESSIBLE_OBJECT_EVENT(3400),
         ;
 
         override fun code(): Int {
@@ -38,6 +43,10 @@ enum class ErrorType {
     enum class NotFound(private val code: Int): Error {
         DEFAULT(4000),
         USER_NOT_FOUND(4001),
+        PROJECT_NOT_FOUND(4200),
+        PROJECT_PAGE_NOT_FOUND(4300),
+        PAGE_OBJECT_NOT_FOUND(4400),
+        OBJECT_EVENT_NOT_FOUND(4500),
         ;
 
         override fun code(): Int {

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamControllerAdvice.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamControllerAdvice.kt
@@ -1,10 +1,12 @@
 package com.wafflestudio.webgam.global.common.exception
 
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.JSON_PARSE_ERROR
 import jakarta.validation.ConstraintViolationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -28,7 +30,7 @@ class WebgamControllerAdvice {
     }
 
     @ExceptionHandler(ConstraintViolationException::class)
-    fun constraintViolation(e: ConstraintViolationException): ResponseEntity<ErrorResponse?> {
+    fun constraintViolation(e: ConstraintViolationException): ResponseEntity<ErrorResponse> {
         return ResponseEntity(
             ErrorResponse(
             ErrorType.BadRequest.CONSTRAINT_VIOLATION.code(),
@@ -39,6 +41,14 @@ class WebgamControllerAdvice {
             }
         ), HttpStatus.BAD_REQUEST)
     }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun jsonParseError(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity(
+            ErrorResponse(JSON_PARSE_ERROR.code(), "Json parse error", "Check your request body."),
+            HttpStatus.BAD_REQUEST)
+    }
+
 
     @ExceptionHandler(WebgamException.Unauthorized::class)
     fun unauthorized(webgamException: WebgamException): ResponseEntity<ErrorResponse> {

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/model/BaseTimeTraceLazyDeletedEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/model/BaseTimeTraceLazyDeletedEntity.kt
@@ -27,4 +27,8 @@ open class BaseTimeTraceLazyDeletedEntity (
     open var modifiedBy: String = "",
 
     open var isDeleted: Boolean = false,
-)
+) {
+    open fun delete() { // FIXME: open -> abstract
+        isDeleted = true
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/model/WebgamAccessModel.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/model/WebgamAccessModel.kt
@@ -2,4 +2,5 @@ package com.wafflestudio.webgam.global.common.model
 
 interface WebgamAccessModel {
     fun isAccessibleTo(currentUserId: Long): Boolean
+    // TODO: isAccessibleTo -> isReadableTo, isWritableTo
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/global/config/QueryDslConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/config/QueryDslConfig.kt
@@ -1,0 +1,19 @@
+package com.wafflestudio.webgam.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig {
+
+    @PersistenceContext
+    lateinit var entityManager: EntityManager
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,10 +56,19 @@ spring:
     generate-ddl: true
     hibernate:
       ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        highlight_sql: true
+        generate_statistics: true
 
 logging:
   level:
     org.springframework.security: TRACE
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.sql: DEBUG
+    org.hibernate.stat: DEBUG
 
 ---
 

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -469,6 +469,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_user_다른_유저_정보_조회하기">User: 다른 유저 정보 조회하기</a></li>
 </ul>
 </li>
+<li><a href="#Object">Object API</a>
+<ul class="sectlevel2">
+<li><a href="#_프로젝트_내_모든_오브젝트_조회하기">프로젝트 내 모든 오브젝트 조회하기</a></li>
+<li><a href="#_오브젝트_생성하기">오브젝트 생성하기</a></li>
+<li><a href="#_오브젝트_조회하기">오브젝트 조회하기</a></li>
+<li><a href="#_오브젝트_수정하기">오브젝트 수정하기</a></li>
+<li><a href="#_오브젝트_삭제하기">오브젝트 삭제하기</a></li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
@@ -514,7 +523,7 @@ pong</code></pre>
 <div class="title">Request</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /auth-ping HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc1MTgzMzExLCJyb2xlIjoiVVNFUiJ9.2ukm6gI_LjnI6MTEMVEyPmTW0818fdL3laKP0vSYGIY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTY3MDgxNCwiZXhwIjoxNjc1Njc4MDE0LCJyb2xlIjoiVVNFUiJ9.DuB6Jm_9f8SvYg-tRnEHqv1_aqyrBWUlAbLLFOKCZ9s
 Host: docs.api.com</code></pre>
 </div>
 </div>
@@ -682,7 +691,7 @@ Host: docs.api.com
 <div class="title">Response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc2Mzg1NzExfQ.lJgxNQHJTo-EywUUksPAothbG7UKXt2CGwV47ZZWc5Y; Path=/; HttpOnly; SameSite=None
+Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTY3MDgxMywiZXhwIjoxNjc2ODgwNDEzfQ.unpT3MP7s-hMUCK9BFC1ZwWrw0l-N1vD7xz9Edbodf0; Path=/; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 316
 
@@ -693,7 +702,7 @@ Content-Length: 316
     "email" : "foo@wafflestudio.com"
   },
   "message" : "login success",
-  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc1MTgzMzExLCJyb2xlIjoiVVNFUiJ9.2ukm6gI_LjnI6MTEMVEyPmTW0818fdL3laKP0vSYGIY"
+  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTY3MDgxMywiZXhwIjoxNjc1Njc4MDEzLCJyb2xlIjoiVVNFUiJ9.aYG9Muh-oXGznphRs1R2JPe6GIIpZBRyyP4Msp8RxCE"
 }</code></pre>
 </div>
 </div>
@@ -707,7 +716,7 @@ Content-Length: 228
 {
   "error_code" : 1,
   "error_message" : "Invalid request parameter or request body",
-  "detail" : "username must not be blank. password must not be blank. userId must not be blank. email must be a well-formed email address."
+  "detail" : "userId must not be blank. email must be a well-formed email address. username must not be blank. password must not be blank."
 }</code></pre>
 </div>
 </div>
@@ -800,7 +809,7 @@ Host: docs.api.com
 <div class="title">Response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc2Mzg1NzExfQ.lJgxNQHJTo-EywUUksPAothbG7UKXt2CGwV47ZZWc5Y; Path=/; HttpOnly; SameSite=None
+Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTY3MDgxMywiZXhwIjoxNjc2ODgwNDEzfQ.unpT3MP7s-hMUCK9BFC1ZwWrw0l-N1vD7xz9Edbodf0; Path=/; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 319
 
@@ -811,7 +820,7 @@ Content-Length: 319
     "email" : "unqiue@wafflestudio.com"
   },
   "message" : "login success",
-  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc1MTgzMzExLCJyb2xlIjoiVVNFUiJ9.2ukm6gI_LjnI6MTEMVEyPmTW0818fdL3laKP0vSYGIY"
+  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTY3MDgxMywiZXhwIjoxNjc1Njc4MDEzLCJyb2xlIjoiVVNFUiJ9.aYG9Muh-oXGznphRs1R2JPe6GIIpZBRyyP4Msp8RxCE"
 }</code></pre>
 </div>
 </div>
@@ -844,7 +853,7 @@ Content-Length: 131
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /refresh HTTP/1.1
 Host: docs.api.com
-Cookie: refresh_token=Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc2Mzg1NzExfQ.lJgxNQHJTo-EywUUksPAothbG7UKXt2CGwV47ZZWc5Y
+Cookie: refresh_token=Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTY3MDgxNCwiZXhwIjoxNjc2ODgwNDE0fQ.-LVQXmf6I_3XVVQwfZQmajMu2cSqMO7TjOBjXIY1iKs
 Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
@@ -871,12 +880,12 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="title">Response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc2Mzg1NzExfQ.lJgxNQHJTo-EywUUksPAothbG7UKXt2CGwV47ZZWc5Y; Path=/; HttpOnly; SameSite=None
+Set-Cookie: refresh_token=Bearer+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTY3MDgxNCwiZXhwIjoxNjc2ODgwNDE0fQ.-LVQXmf6I_3XVVQwfZQmajMu2cSqMO7TjOBjXIY1iKs; Path=/; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 163
 
 {
-  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTE3NjExMSwiZXhwIjoxNjc1MTgzMzExfQ.kvxsSyu22yS_OjCFnbAUpX0Rau9IAbmP9yKo9Rx_-1E"
+  "access_token" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmb29JZCIsImlhdCI6MTY3NTY3MDgxNCwiZXhwIjoxNjc1Njc4MDE0fQ.CXYAZbV1cB2_gtikaMFXrNckd-Y_9aRTBIpvV3MAT00"
 }</code></pre>
 </div>
 </div>
@@ -1051,7 +1060,7 @@ Content-Length: 186
 {
   "error_code" : 1,
   "error_message" : "Invalid request parameter or request body",
-  "detail" : "email must be a well-formed email address. username can be nullable but not blank."
+  "detail" : "username can be nullable but not blank. email must be a well-formed email address."
 }</code></pre>
 </div>
 </div>
@@ -1154,11 +1163,823 @@ Content-Length: 112
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="Object"><a class="link" href="#Object">Object API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_프로젝트_내_모든_오브젝트_조회하기"><a class="link" href="#_프로젝트_내_모든_오브젝트_조회하기">프로젝트 내 모든 오브젝트 조회하기</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/objects?project-id=1 HTTP/1.1
+Host: docs.api.com</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 6. Query Parameter</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>project-id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 프로젝트 ID</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 1658
+
+{
+  "count" : 3,
+  "data" : [ {
+    "id" : 1,
+    "created_at" : "2023-02-06T17:06:47.592226",
+    "created_by" : "",
+    "modified_at" : "2023-02-06T17:06:47.592226",
+    "modified_by" : "",
+    "name" : "default-object",
+    "type" : "DEFAULT",
+    "width" : 10,
+    "height" : 10,
+    "text_content" : null,
+    "font_size" : null,
+    "image_source" : null,
+    "page_id" : 1,
+    "is_interactive" : true,
+    "event" : {
+      "id" : 1,
+      "created_at" : "2023-02-06T17:06:47.690692",
+      "created_by" : "",
+      "modified_at" : "2023-02-06T17:06:47.690692",
+      "modified_by" : "",
+      "transition_type" : "DEFAULT"
+    },
+    "zindex" : 0,
+    "xposition" : 0,
+    "yposition" : 0
+  }, {
+    "id" : 4,
+    "created_at" : "2023-02-06T17:06:47.750719",
+    "created_by" : "",
+    "modified_at" : "2023-02-06T17:06:47.750719",
+    "modified_by" : "",
+    "name" : "image-object",
+    "type" : "IMAGE",
+    "width" : 100,
+    "height" : 20,
+    "text_content" : null,
+    "font_size" : null,
+    "image_source" : "http://image-source.url",
+    "page_id" : 1,
+    "is_interactive" : false,
+    "event" : null,
+    "zindex" : 1,
+    "xposition" : 30,
+    "yposition" : 40
+  }, {
+    "id" : 5,
+    "created_at" : "2023-02-06T17:06:47.752435",
+    "created_by" : "",
+    "modified_at" : "2023-02-06T17:06:47.752435",
+    "modified_by" : "",
+    "name" : "text-object",
+    "type" : "TEXT",
+    "width" : 30,
+    "height" : 60,
+    "text_content" : "some text",
+    "font_size" : 16,
+    "image_source" : null,
+    "page_id" : 1,
+    "is_interactive" : false,
+    "event" : null,
+    "zindex" : 2,
+    "xposition" : -10,
+    "yposition" : -20
+  } ]
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Error Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 124
+
+{
+  "error_code" : 3,
+  "error_message" : "Constraint violations",
+  "detail" : "projectId must be greater than 0, but 0."
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 127
+
+{
+  "error_code" : 3100,
+  "error_message" : "NON_ACCESSIBLE_PROJECT",
+  "detail" : "You have no access to Project with id 2"
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 404 Not Found
+Content-Type: application/json
+Content-Length: 117
+
+{
+  "error_code" : 4200,
+  "error_message" : "PROJECT_NOT_FOUND",
+  "detail" : "Project with id 3 does not exists."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_오브젝트_생성하기"><a class="link" href="#_오브젝트_생성하기">오브젝트 생성하기</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/objects HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 216
+Host: docs.api.com
+
+{
+  "page_id" : 1,
+  "name" : "create object test: image",
+  "type" : "IMAGE",
+  "width" : 200,
+  "height" : 50,
+  "x_position" : 20,
+  "y_position" : -10,
+  "z_index" : 2,
+  "image_source" : "https://docs.api.com"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 7. Request Body</caption>
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필드명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필수여부</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Default 값</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">포맷 및 제약조건</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예시</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page_id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 초과</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 ID</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">오브젝트 이름</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>type</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">DEFAULT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">DEFAULT|TEXT|IMAGE</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">오브젝트 타입</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>width</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 초과</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">너비</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>height</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 초과</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">높이</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>x_position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">x축 위치</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>y_position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">y축 위치</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>z_index</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 이상</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">깊이</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>text_content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">텍스트 내용</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>font_size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 초과</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">텍스트 폰트 크기</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>image_source</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효한 URL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 URL</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 405
+
+{
+  "id" : 6,
+  "created_at" : "2023-02-06T17:06:48.573344",
+  "created_by" : "fooId",
+  "modified_at" : "2023-02-06T17:06:48.573344",
+  "modified_by" : "fooId",
+  "name" : "create object test: image",
+  "type" : "IMAGE",
+  "width" : 200,
+  "height" : 50,
+  "text_content" : null,
+  "font_size" : null,
+  "image_source" : "http://sampe-image.url",
+  "zindex" : 2,
+  "xposition" : 20,
+  "yposition" : -10
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Error Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 288
+
+{
+  "error_code" : 1,
+  "error_message" : "Invalid request parameter or request body",
+  "detail" : "width must not be null. name must not be blank. pageId must be greater than 0. zIndex must not be null. xPosition must not be null. height must not be null. yPosition must not be null."
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 103
+
+{
+  "error_code" : 4,
+  "error_message" : "Json parse error",
+  "detail" : "Check your request body."
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 129
+
+{
+  "error_code" : 3200,
+  "error_message" : "NON_ACCESSIBLE_PROJECT_PAGE",
+  "detail" : "You have no access to Page with id 2"
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 404 Not Found
+Content-Type: application/json
+Content-Length: 119
+
+{
+  "error_code" : 4300,
+  "error_message" : "PROJECT_PAGE_NOT_FOUND",
+  "detail" : "Page with id 3 does not exists."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_오브젝트_조회하기"><a class="link" href="#_오브젝트_조회하기">오브젝트 조회하기</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/objects/1 HTTP/1.1
+Host: docs.api.com</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 8. /api/v1/objects/{id}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">오브젝트 ID</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 619
+
+{
+  "id" : 1,
+  "created_at" : "2023-02-06T17:06:47.592226",
+  "created_by" : "",
+  "modified_at" : "2023-02-06T17:06:47.592226",
+  "modified_by" : "",
+  "name" : "default-object",
+  "type" : "DEFAULT",
+  "width" : 10,
+  "height" : 10,
+  "text_content" : null,
+  "font_size" : null,
+  "image_source" : null,
+  "page_id" : 1,
+  "is_interactive" : true,
+  "event" : {
+    "id" : 1,
+    "created_at" : "2023-02-06T17:06:47.690692",
+    "created_by" : "",
+    "modified_at" : "2023-02-06T17:06:47.690692",
+    "modified_by" : "",
+    "transition_type" : "DEFAULT"
+  },
+  "zindex" : 0,
+  "xposition" : 0,
+  "yposition" : 0
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Error Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 123
+
+{
+  "error_code" : 3,
+  "error_message" : "Constraint violations",
+  "detail" : "objectId must be greater than 0, but 0."
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 130
+
+{
+  "error_code" : 3300,
+  "error_message" : "NON_ACCESSIBLE_PAGE_OBJECT",
+  "detail" : "You have no access to Object with id 2"
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 404 Not Found
+Content-Type: application/json
+Content-Length: 120
+
+{
+  "error_code" : 4400,
+  "error_message" : "PAGE_OBJECT_NOT_FOUND",
+  "detail" : "Object with id 3 does not exists."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_오브젝트_수정하기"><a class="link" href="#_오브젝트_수정하기">오브젝트 수정하기</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/objects/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 189
+Host: docs.api.com
+
+{
+  "type" : "TEXT",
+  "width" : 20,
+  "height" : 100,
+  "x_position" : -20,
+  "y_position" : 10,
+  "z_index" : 0,
+  "text_content" : "new text",
+  "font_size" : 20,
+  "image_source" : ""
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 9. /api/v1/objects/{id}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">오브젝트 ID</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 10. Request Body</caption>
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필드명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필수여부</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Default 값</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">포맷 및 제약조건</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예시</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>type</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">DEFAULT|TEXT|IMAGE</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">오브젝트 타입</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>width</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 초과</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">너비</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>height</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 초과</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">높이</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>x_position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">x축 위치</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>y_position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">y축 위치</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>z_index</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 이상</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">깊이</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>text_content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">텍스트 내용</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>font_size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 초과</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">텍스트 폰트 크기</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>image_source</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효한 URL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 URL</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 622
+
+{
+  "id" : 1,
+  "created_at" : "2023-02-06T17:06:47.592226",
+  "created_by" : "",
+  "modified_at" : "2023-02-06T17:06:47.592226",
+  "modified_by" : "",
+  "name" : "default-object",
+  "type" : "TEXT",
+  "width" : 20,
+  "height" : 100,
+  "text_content" : "new text",
+  "font_size" : 20,
+  "image_source" : "",
+  "page_id" : 1,
+  "is_interactive" : true,
+  "event" : {
+    "id" : 1,
+    "created_at" : "2023-02-06T17:06:47.690692",
+    "created_by" : "",
+    "modified_at" : "2023-02-06T17:06:47.690692",
+    "modified_by" : "",
+    "transition_type" : "DEFAULT"
+  },
+  "zindex" : 0,
+  "xposition" : -20,
+  "yposition" : 10
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Error Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 123
+
+{
+  "error_code" : 3,
+  "error_message" : "Constraint violations",
+  "detail" : "objectId must be greater than 0, but 0."
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 103
+
+{
+  "error_code" : 4,
+  "error_message" : "Json parse error",
+  "detail" : "Check your request body."
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 130
+
+{
+  "error_code" : 3300,
+  "error_message" : "NON_ACCESSIBLE_PAGE_OBJECT",
+  "detail" : "You have no access to Object with id 2"
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 404 Not Found
+Content-Type: application/json
+Content-Length: 120
+
+{
+  "error_code" : 4400,
+  "error_message" : "PAGE_OBJECT_NOT_FOUND",
+  "detail" : "Object with id 3 does not exists."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_오브젝트_삭제하기"><a class="link" href="#_오브젝트_삭제하기">오브젝트 삭제하기</a></h3>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/objects/1 HTTP/1.1
+Host: docs.api.com</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 11. /api/v1/objects/{id}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">오브젝트 ID</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Error Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 123
+
+{
+  "error_code" : 3,
+  "error_message" : "Constraint violations",
+  "detail" : "objectId must be greater than 0, but 0."
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 130
+
+{
+  "error_code" : 3300,
+  "error_message" : "NON_ACCESSIBLE_PAGE_OBJECT",
+  "detail" : "You have no access to Object with id 2"
+}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 404 Not Found
+Content-Type: application/json
+Content-Length: 120
+
+{
+  "error_code" : 4400,
+  "error_message" : "PAGE_OBJECT_NOT_FOUND",
+  "detail" : "Object with id 3 does not exists."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-01-31 23:34:18 +0900
+Last updated 2023-02-06 16:47:02 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/kotlin/com/wafflestudio/webgam/TestUtils.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/TestUtils.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.webgam
+
+class TestUtils {
+    companion object {
+        fun makeFieldList(vararg fields: List<Pair<Any?, Int?>>): List<Pair<List<Any?>, Pair<Int, Int?>>> {
+            val main: MutableList<Pair<MutableList<Any?>, Pair<Int, Int?>>> = mutableListOf()
+            val defaultValues = fields.map { it.first { (_, t) -> t == null }.first }
+
+            for (idx in fields.indices) {
+                val field = fields[idx]
+                field.forEach { (d, t) ->
+                    if (d == defaultValues[idx]) return@forEach
+                    val copy = defaultValues.toMutableList()
+                    copy[idx] = d
+                    main.add(copy to ((if (t == null) -1 else idx) to t))
+                }
+            }
+
+            return main
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/object/ObjectDescribeSpec.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/object/ObjectDescribeSpec.kt
@@ -1,0 +1,609 @@
+package com.wafflestudio.webgam.domain.`object`
+
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import com.wafflestudio.webgam.ENUM
+import com.wafflestudio.webgam.NUMBER
+import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentRequest
+import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentResponse
+import com.wafflestudio.webgam.RestDocsUtils.Companion.requestBody
+import com.wafflestudio.webgam.STRING
+import com.wafflestudio.webgam.domain.event.model.ObjectEvent
+import com.wafflestudio.webgam.domain.event.model.TransitionType
+import com.wafflestudio.webgam.domain.event.repository.ObjectEventRepository
+import com.wafflestudio.webgam.domain.`object`.model.PageObject
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.*
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.DEFAULT
+import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
+import com.wafflestudio.webgam.domain.page.model.ProjectPage
+import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.*
+import com.wafflestudio.webgam.global.common.exception.ErrorType.Forbidden.*
+import com.wafflestudio.webgam.global.common.exception.ErrorType.NotFound.*
+import com.wafflestudio.webgam.global.security.model.UserPrincipal
+import com.wafflestudio.webgam.global.security.model.WebgamAuthenticationToken
+import com.wafflestudio.webgam.type
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.hamcrest.core.Is.`is`
+import org.junit.jupiter.api.Tag
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*
+import org.springframework.restdocs.request.RequestDocumentation.*
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@Tag("Integration-Test")
+@DisplayName("Object 통합 테스트")
+class ObjectDescribeSpec(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val userRepository: UserRepository,
+    @Autowired private val projectRepository: ProjectRepository,
+    @Autowired private val projectPageRepository: ProjectPageRepository,
+    @Autowired private val pageObjectRepository: PageObjectRepository,
+    @Autowired private val objectEventRepository: ObjectEventRepository,
+): DescribeSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    final val user = userRepository.save(User("fooId", "foo", "foo@wafflestudio.com", ""))
+    private final val dummyUser = userRepository.save(User("barId", "bar", "bar@wafflestudio.com", ""))
+    private final val auth = WebgamAuthenticationToken(UserPrincipal(user), "")
+    private final val project = projectRepository.save(Project(user, "test-project"))
+    private final val dummyProject = projectRepository.save(Project(dummyUser, "test-project"))
+    private final val page = projectPageRepository.save(ProjectPage(project, "test-page"))
+    private final val dummyPage = projectPageRepository.save(ProjectPage(dummyProject, "test-page"))
+    private final val defaultObject = pageObjectRepository.save(PageObject(page, "default-object", DEFAULT,
+        10, 10, 0, 0, 0, null, null, null, null))
+    private final val dummyObject = pageObjectRepository.save(PageObject(dummyPage, "default-object", DEFAULT,
+        10, 10, 0, 0, 0, null, null, null, null))
+
+    private lateinit var deletedProject: Project
+    private lateinit var deletedPage: ProjectPage
+    private lateinit var deletedObject: PageObject
+
+    override suspend fun beforeSpec(spec: Spec) {
+        val p = Project(user, "deleted-project")
+        p.isDeleted = true
+        val pp = ProjectPage(project, "deleted-page")
+        pp.isDeleted = true
+        val po = PageObject(page, "deleted-object", DEFAULT, 10, 10, 0, 0, 0, null, null, null, null)
+        po.isDeleted = true
+
+        withContext(Dispatchers.IO) {
+            deletedProject = projectRepository.save(p)
+            deletedPage = projectPageRepository.save(pp)
+            deletedObject = pageObjectRepository.save(po)
+            objectEventRepository.save(ObjectEvent(defaultObject, null, TransitionType.DEFAULT))
+        }
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            pageObjectRepository.deleteAll()
+            projectPageRepository.deleteAll()
+            projectRepository.deleteAll()
+            userRepository.deleteAll()
+        }
+    }
+
+    companion object {
+        private val gson = GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+    }
+
+    init {
+        this.describe("프로젝트 내 오브젝트 조회할 때") {
+            context("성공하면") {
+                withContext(Dispatchers.IO) {
+                    val objects = listOf(
+                        PageObject(page, "image-object", IMAGE, 100, 20, 30, 40, 1, null, null, "http://image-source.url", null),
+                        PageObject(page, "text-object", TEXT, 30, 60, -10, -20, 2, "some text", 16, null, null)
+                    )
+                    pageObjectRepository.saveAll(objects)
+                }
+
+                it("200 OK") {
+                    mockMvc.perform(
+                        get("/api/v1/objects")
+                            .param("project-id", project.id.toString())
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "get-project-objects/200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        queryParameters(parameterWithName("project-id").description("조회할 프로젝트 ID")),
+                    )).andExpect(status().isOk).andDo(print())
+                }
+            }
+
+            context("올바르지 않은 프로젝트 ID일 때") {
+                val errorCode = CONSTRAINT_VIOLATION.code()
+
+                it("400 Bad Request, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        get("/api/v1/objects")
+                            .param("project-id", "0")
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "get-project-objects/400-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 프로젝트에 접근하지 못하는 경우") {
+                val errorCode = NON_ACCESSIBLE_PROJECT.code()
+
+                it("403 Forbidden, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        get("/api/v1/objects")
+                            .param("project-id", dummyProject.id.toString())
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "get-project-objects/403-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isForbidden
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 프로젝트가 없거나 삭제 되었을 때") {
+                val errorCode = PROJECT_NOT_FOUND.code()
+
+                it("404 Not Found, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        get("/api/v1/objects")
+                            .param("project-id", deletedProject.id.toString())
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "get-project-objects/404-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isNotFound
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+        }
+
+        this.describe("오브젝트 생성할 때") {
+            context("성공하면") {
+                val request = mapOf(
+                    "page_id" to page.id,
+                    "name" to "create object test: image",
+                    "type" to IMAGE,
+                    "width" to 200,
+                    "height" to 50,
+                    "x_position" to 20,
+                    "y_position" to -10,
+                    "z_index" to 2,
+                    "text_content" to null,
+                    "font_size" to null,
+                    "image_source" to "http://sampe-image.url"
+                )
+
+                it("200 OK") {
+                    mockMvc.perform(
+                        post("/api/v1/objects")
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "create-object/200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestBody(
+                            "page_id" type NUMBER means "페이지 ID" formattedAs "0 초과",
+                            "name" type STRING means "오브젝트 이름",
+                            "type" type ENUM(PageObjectType::class) means "오브젝트 타입" withDefaultValue "DEFAULT",
+                            "width" type NUMBER means "너비" formattedAs "0 초과",
+                            "height" type NUMBER means "높이" formattedAs "0 초과",
+                            "x_position" type NUMBER means "x축 위치",
+                            "y_position" type NUMBER means "y축 위치",
+                            "z_index" type NUMBER means "깊이" formattedAs "0 이상",
+                            "text_content" type STRING means "텍스트 내용" isOptional true,
+                            "font_size" type NUMBER means "텍스트 폰트 크기" isOptional true formattedAs "0 초과",
+                            "image_source" type STRING means "이미지 URL" isOptional true formattedAs "유효한 URL",
+                        )
+                    )).andExpect(status().isOk).andDo(print())
+                }
+            }
+
+            context("올바르지 않은 값을 넣거나 필수값이 없을 때") {
+                val request = mapOf("page_id" to "0")
+
+                val errorCode = INVALID_FIELD.code()
+
+                it("400 Bad Request, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        post("/api/v1/objects")
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "create-object/400-0",
+                        getDocumentResponse(),
+                    )).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("올바르지 않은 타입을 넣을 때") {
+                val request = mapOf("page_id" to "non int")
+
+                val errorCode = JSON_PARSE_ERROR.code()
+
+                it("400 Bad Request, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        post("/api/v1/objects")
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "create-object/400-1",
+                        getDocumentResponse(),
+                    )).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 페이지에 접근하지 못하는 경우") {
+                val request = mapOf(
+                    "page_id" to dummyPage.id,
+                    "name" to "create object test: image",
+                    "type" to IMAGE,
+                    "width" to 200,
+                    "height" to 50,
+                    "x_position" to 20,
+                    "y_position" to -10,
+                    "z_index" to 2,
+                    "text_content" to null,
+                    "font_size" to null,
+                    "image_source" to "http://sampe-image.url"
+                )
+
+                val errorCode = NON_ACCESSIBLE_PROJECT_PAGE.code()
+
+                it("403 Forbidden, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        post("/api/v1/objects")
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "create-object/403-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isForbidden
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 페이지가 없거나 삭제 되었을 때") {
+                val request = mapOf(
+                    "page_id" to deletedPage.id,
+                    "name" to "create object test: image",
+                    "type" to IMAGE,
+                    "width" to 200,
+                    "height" to 50,
+                    "x_position" to 20,
+                    "y_position" to -10,
+                    "z_index" to 2,
+                    "text_content" to null,
+                    "font_size" to null,
+                    "image_source" to "http://sampe-image.url"
+                )
+
+                val errorCode = PROJECT_PAGE_NOT_FOUND.code()
+
+                it("404 Not Found, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        post("/api/v1/objects")
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "create-object/404-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isNotFound
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+        }
+
+        this.describe("오브젝트 조회할 때") {
+            context("성공하면") {
+                it("200 OK") {
+                    mockMvc.perform(
+                        get("/api/v1/objects/{id}", defaultObject.id.toString())
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "get-object/200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(parameterWithName("id").description("오브젝트 ID"))
+                    )).andExpect(status().isOk).andDo(print())
+                }
+            }
+
+            context("올바르지 않은 오브젝트 ID일 때") {
+                val errorCode = CONSTRAINT_VIOLATION.code()
+
+                it("400 Bad Request, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        get("/api/v1/objects/{id}", "0")
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "get-object/400-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 오브젝트에 접근하지 못하는 경우") {
+                val errorCode = NON_ACCESSIBLE_PAGE_OBJECT.code()
+
+                it("403 Forbidden, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        get("/api/v1/objects/{id}", dummyObject.id.toString())
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "get-object/403-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isForbidden
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 오브젝트가 없거나 삭제 되었을 때") {
+                val errorCode = PAGE_OBJECT_NOT_FOUND.code()
+
+                it("404 Not Found, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        get("/api/v1/objects/{id}", deletedObject.id.toString())
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "get-object/404-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isNotFound
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+        }
+
+        this.describe("오브젝트 수정할 때") {
+            context("성공하면") {
+                val request = mapOf(
+                    "type" to TEXT,
+                    "width" to 20,
+                    "height" to 100,
+                    "x_position" to -20,
+                    "y_position" to 10,
+                    "z_index" to 0,
+                    "text_content" to "new text",
+                    "font_size" to 20,
+                    "image_source" to ""
+                )
+
+                it("200 OK") {
+                    mockMvc.perform(
+                        patch("/api/v1/objects/{id}", defaultObject.id.toString())
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "patch-object/200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(parameterWithName("id").description("오브젝트 ID")),
+                        requestBody(
+                            "type" type ENUM(PageObjectType::class) means "오브젝트 타입" isOptional false,
+                            "width" type NUMBER means "너비" formattedAs "0 초과" isOptional false,
+                            "height" type NUMBER means "높이" formattedAs "0 초과" isOptional false,
+                            "x_position" type NUMBER means "x축 위치" isOptional false,
+                            "y_position" type NUMBER means "y축 위치" isOptional false,
+                            "z_index" type NUMBER means "깊이" formattedAs "0 이상" isOptional false,
+                            "text_content" type STRING means "텍스트 내용" isOptional true,
+                            "font_size" type NUMBER means "텍스트 폰트 크기" isOptional true formattedAs "0 초과",
+                            "image_source" type STRING means "이미지 URL" isOptional true formattedAs "유효한 URL",
+                        )
+                    )).andExpect(status().isOk).andDo(print())
+                }
+            }
+
+            context("올바르지 않은 값을 넣을 때") {
+                val request = mapOf("width" to "0")
+
+                val errorCode = INVALID_FIELD.code()
+
+                it("400 Bad Request, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        patch("/api/v1/objects/{id}", defaultObject.id.toString())
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "patch-object/400-0",
+                        getDocumentResponse(),
+                    )).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("올바르지 않은 타입을 넣을 때") {
+                val request = mapOf("width" to "non int")
+
+                val errorCode = JSON_PARSE_ERROR.code()
+
+                it("400 Bad Request, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        patch("/api/v1/objects/{id}", defaultObject.id.toString())
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "patch-object/400-1",
+                        getDocumentResponse(),
+                    )).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("올바르지 않은 오브젝트 ID일 때") {
+                val request = mapOf("width" to "1")
+
+                val errorCode = CONSTRAINT_VIOLATION.code()
+
+                it("400 Bad Request, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        patch("/api/v1/objects/{id}", "0")
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "patch-object/400-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 오브젝트에 접근하지 못하는 경우") {
+                val request = mapOf("width" to "1")
+
+                val errorCode = NON_ACCESSIBLE_PAGE_OBJECT.code()
+
+                it("403 Forbidden, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        patch("/api/v1/objects/{id}", dummyObject.id.toString())
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "patch-object/403-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isForbidden
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 오브젝트가 없거나 삭제 되었을 때") {
+                val request = mapOf("width" to "1")
+
+                val errorCode = PAGE_OBJECT_NOT_FOUND.code()
+
+                it("404 Not Found, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        patch("/api/v1/objects/{id}", deletedObject.id.toString())
+                            .contentType(APPLICATION_JSON)
+                            .content(gson.toJson(request))
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "patch-object/404-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isNotFound
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+        }
+
+        this.describe("오브젝트 삭제할 때") {
+            context("성공하면") {
+                it("200 OK") {
+                    mockMvc.perform(
+                        delete("/api/v1/objects/{id}", defaultObject.id.toString())
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "delete-object/200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(parameterWithName("id").description("오브젝트 ID")),
+                    )).andExpect(status().isOk).andDo(print())
+                }
+            }
+
+            context("올바르지 않은 오브젝트 ID일 때") {
+                val errorCode = CONSTRAINT_VIOLATION.code()
+
+                it("400 Bad Request, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        delete("/api/v1/objects/{id}", "0")
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "delete-object/400-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isBadRequest
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 오브젝트에 접근하지 못하는 경우") {
+                val errorCode = NON_ACCESSIBLE_PAGE_OBJECT.code()
+
+                it("403 Forbidden, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        delete("/api/v1/objects/{id}", dummyObject.id.toString())
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "delete-object/403-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isForbidden
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+
+            context("해당 ID를 갖는 오브젝트가 없거나 삭제 되었을 때") {
+                val errorCode = PAGE_OBJECT_NOT_FOUND.code()
+
+                it("404 Not Found, 에러코드 $errorCode") {
+                    mockMvc.perform(
+                        delete("/api/v1/objects/{id}", deletedObject.id.toString())
+                            .with(authentication(auth))
+                    ).andDo(document(
+                        "delete-object/404-0",
+                        getDocumentResponse()
+                    )).andExpect(status().isNotFound
+                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
+                    ).andDo(print())
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/object/controller/PageObjectControllerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/object/controller/PageObjectControllerTest.kt
@@ -1,0 +1,356 @@
+package com.wafflestudio.webgam.domain.`object`.controller
+
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.webgam.TestUtils
+import com.wafflestudio.webgam.domain.`object`.dto.PageObjectDto.DetailedResponse
+import com.wafflestudio.webgam.domain.`object`.dto.PageObjectDto.SimpleResponse
+import com.wafflestudio.webgam.domain.`object`.model.PageObject
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.DEFAULT
+import com.wafflestudio.webgam.domain.`object`.service.PageObjectService
+import com.wafflestudio.webgam.domain.page.model.ProjectPage
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.global.common.dto.ListResponse
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.*
+import com.wafflestudio.webgam.global.security.model.UserPrincipal
+import com.wafflestudio.webgam.global.security.model.WebgamAuthenticationToken
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import org.hamcrest.core.Is.`is`
+import org.junit.jupiter.api.Tag
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.*
+
+@WebMvcTest(PageObjectController::class)
+@MockkBean(JpaMetamodelMappingContext::class)
+@ActiveProfiles("test")
+@Tag("Unit-Test")
+@DisplayName("PageObjectController 단위 테스트")
+class PageObjectControllerTest(
+    @Autowired private val mockMvc: MockMvc,
+    @MockkBean private val pageObjectService: PageObjectService,
+) : DescribeSpec() {
+
+    companion object {
+        private val gson = GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+        private val user = User("", "", "", "")
+        private val authentication = WebgamAuthenticationToken(UserPrincipal(user), "")
+        private val project = mockk<Project>()
+        private val page = ProjectPage(project, "test-page")
+        private val pageObject = PageObject(page, "test-object", DEFAULT, 0, 0, 0, 0, 0, "", 0, "", null)
+
+        /* Test Parameters */
+        private val ids = listOf(
+            listOf("1", "3", "5", "100").map { it to null },
+            listOf("0", "-1", "-100").map { it to CONSTRAINT_VIOLATION.code() }).flatten()
+    }
+
+    init {
+        this.describe("특정 프로젝트의 모든 오브젝트를 조회할 때") {
+            every { pageObjectService.listProjectObjects(any(), any()) } returns ListResponse(listOf(DetailedResponse(pageObject)))
+
+            val ids = TestUtils.makeFieldList(ids)
+
+            ids.forAll { (i, t) ->
+                val (idx, code) = t
+                val id = i[0].toString()
+
+                if (idx == -1) context("ID가 올바른 값 '${id}'이면") {
+                    it("200 OK") {
+                        mockMvc.get("/api/v1/objects") {
+                            param("project-id", id)
+                            with(authentication(authentication))
+                        }.andExpect { status { isOk() } }
+                    }
+                }
+                else context("ID가 올바르지 않은 값 '${id}'이면") {
+                    it("400 Bad Request, 에러코드 $code") {
+                        mockMvc.get("/api/v1/objects") {
+                            param("project-id", id)
+                            with(authentication(authentication))
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", `is`(code))
+                        }.andDo { print() }
+                    }
+                }
+            }
+        }
+
+        this.describe("오브젝트 생성할 때") {
+            every { pageObjectService.createObject(any(), any()) } returns SimpleResponse(pageObject)
+
+            /* Test Parameters */
+            val pageIds = listOf(
+                listOf(1, 3, 4, 10).map { it to null },
+                listOf(-1, 0, null).map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val names = listOf(
+                listOf("valid-object-name").map { it to null },
+                listOf(null).map { it to INVALID_FIELD.code() }).flatten()
+            val objectTypes = listOf(
+                listOf("DEFAULT", "TEXT", "IMAGE", "else-falls-to-default", null).map { it to null },
+                ).flatten()
+            val widths = listOf(
+                listOf(1, 3).map { it to null },
+                listOf(-1, 0, null).map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val heights = listOf(
+                listOf(1, 3).map { it to null },
+                listOf(-1, 0, null).map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val xPositions = listOf(
+                listOf(1, -1, 0).map { it to null },
+                listOf("").map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val yPositions = listOf(
+                listOf(1, -1, 0).map { it to null },
+                listOf("").map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val zIndices = listOf(
+                listOf(0, 1, 3).map { it to null },
+                listOf(-1, null).map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val textContents = listOf(
+                listOf("valid text content", null).map { it to null },
+                ).flatten()
+            val fontSizes = listOf(
+                listOf(1, null).map { it to null },
+                listOf(0, -1).map { it to INVALID_FIELD.code() }).flatten()
+            val imageSources = listOf(
+                listOf("http://valid-url.com", "https://secure-url", null).map { it to null },
+                listOf("something", "with-no-domain").map { it to INVALID_FIELD.code() }).flatten()
+
+            val combinations = TestUtils.makeFieldList(
+                pageIds,
+                names,
+                objectTypes,
+                widths,
+                heights,
+                xPositions,
+                yPositions,
+                zIndices,
+                textContents,
+                fontSizes,
+                imageSources
+            )
+
+            val fields = listOf("page_id", "name", "object_type", "width", "height", "x_position", "y_position",
+                "z_index", "text_content", "font_size", "image_source")
+
+            combinations.forAll { (l, t) ->
+                val (idx, code) = t
+                val request = mapOf(
+                    "page_id" to l[0],
+                    "name" to l[1],
+                    "object_type" to l[2],
+                    "width" to l[3],
+                    "height" to l[4],
+                    "x_position" to l[5],
+                    "y_position" to l[6],
+                    "z_index" to l[7],
+                    "text_content" to l[8],
+                    "font_size" to l[9],
+                    "image_source" to l[10],
+                )
+
+                when (idx) {
+                    -1 -> { context("Body의 모든 field가 올바르면") {
+                        it("200 OK") {
+                            mockMvc.post("/api/v1/objects") {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect { status { isOk() } }
+                        }
+                    } }
+                    else -> { context("${fields[idx]}가 올바르지 않은 값 '${l[idx]}' 이면") {
+                        it ("400 Bad Request, 에러코드 $code") {
+                            mockMvc.post("/api/v1/objects") {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect {
+                                status { isBadRequest() }
+                                jsonPath("$.error_code", `is`(code))
+                            }
+                        }
+                    } }
+                }
+            }
+        }
+
+        this.describe("특정 오브젝트 조회할 때") {
+            every { pageObjectService.getObject(any(), any()) } returns DetailedResponse(pageObject)
+
+            val ids = TestUtils.makeFieldList(ids)
+
+            ids.forAll { (i, t) ->
+                val (idx, code) = t
+                val id = i[0].toString()
+
+                if (idx == -1) context("ID가 올바른 값 '${id}'이면") {
+                    it("200 OK") {
+                        mockMvc.get("/api/v1/objects/{id}", id) {
+                            with(authentication(authentication))
+                        }.andExpect { status { isOk() } }
+                    }
+                }
+                else context("ID가 올바르지 않은 값 '${id}'이면") {
+                    it("400 Bad Request, 에러코드 $code") {
+                        mockMvc.get("/api/v1/objects/{id}", id) {
+                            with(authentication(authentication))
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", `is`(code))
+                        }
+                    }
+                }
+            }
+
+
+
+        }
+
+        this.describe("특정 오브젝트 수정할 때") {
+            every { pageObjectService.modifyObject(any(), any(), any()) } returns DetailedResponse(pageObject)
+
+            /* Test Parameters */
+            val objectTypes = listOf(
+                listOf("DEFAULT", "TEXT", "IMAGE", "else-falls-to-default", null).map { it to null },
+            ).flatten()
+            val widths = listOf(
+                listOf(1, 3, null).map { it to null },
+                listOf(-1, 0).map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val heights = listOf(
+                listOf(1, 3, null, "").map { it to null },
+                listOf(-1, 0).map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val xPositions = listOf(
+                listOf(1, -1, 0, null, "").map { it to null },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val yPositions = listOf(
+                listOf(1, -1, 0, null, "").map { it to null },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val zIndices = listOf(
+                listOf(0, 1, 3, null).map { it to null },
+                listOf(-1).map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val textContents = listOf(
+                listOf("valid text content", null).map { it to null },
+            ).flatten()
+            val fontSizes = listOf(
+                listOf(1, null).map { it to null },
+                listOf(0, -1).map { it to INVALID_FIELD.code() }).flatten()
+            val imageSources = listOf(
+                listOf("http://valid-url.com", "https://secure-url", null).map { it to null },
+                listOf("something", "with-no-domain").map { it to INVALID_FIELD.code() }).flatten()
+
+            val combinations = TestUtils.makeFieldList(
+                ids,
+                objectTypes,
+                widths,
+                heights,
+                xPositions,
+                yPositions,
+                zIndices,
+                textContents,
+                fontSizes,
+                imageSources
+            )
+
+            val fields = listOf("id", "object_type", "width", "height", "x_position", "y_position", "z_index", "text_content", "font_size", "image_source")
+
+            combinations.forAll { (l, t) ->
+                val (idx, code) = t
+                val request = mapOf(
+                    "object_type" to l[1],
+                    "width" to l[2],
+                    "height" to l[3],
+                    "x_position" to l[4],
+                    "y_position" to l[5],
+                    "z_index" to l[6],
+                    "text_content" to l[7],
+                    "font_size" to l[8],
+                    "image_source" to l[9],
+                )
+
+                when (idx) {
+                    -1 -> {
+                        context("Body의 모든 field가 올바르면") {
+                            it("200 OK") {
+                                mockMvc.patch("/api/v1/objects/{id}", l[0]) {
+                                    contentType = MediaType.APPLICATION_JSON
+                                    content = gson.toJson(request)
+                                    with(authentication(authentication))
+                                    with(csrf())
+                                }.andExpect { status { isOk() } }
+                            }
+                        }
+                    }
+                    else -> {
+                        context("${fields[idx]}가 올바르지 않은 값 '${l[idx]}' 이면") {
+                            it("400 Bad Request, 에러코드 $code") {
+                                mockMvc.patch("/api/v1/objects/{id}", l[0]) {
+                                    contentType = MediaType.APPLICATION_JSON
+                                    content = gson.toJson(request)
+                                    with(authentication(authentication))
+                                    with(csrf())
+                                }.andExpect {
+                                    status { isBadRequest() }
+                                    jsonPath("$.error_code", `is`(code))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        this.describe("특정 오브젝트 삭제할 때") {
+            justRun { pageObjectService.deleteObject(any(), any()) }
+
+            val ids = TestUtils.makeFieldList(ids)
+
+            ids.forAll { (i, t) ->
+                val (idx, code) = t
+                val id = i[0].toString()
+
+                if (idx == -1) context("ID가 올바른 값 '${id}'이면") {
+                    it("200 OK") {
+                        mockMvc.delete("/api/v1/objects/{id}", id) {
+                            with(authentication(authentication))
+                            with(csrf())
+                        }.andExpect { status { isOk() } }
+                    }
+                }
+                else context("ID가 올바르지 않은 값 '${id}'이면") {
+                    it("400 Bad Request, 에러코드 $code") {
+                        mockMvc.delete("/api/v1/objects/{id}", id) {
+                            with(authentication(authentication))
+                            with(csrf())
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", `is`(code))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepositoryImplTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepositoryImplTest.kt
@@ -1,0 +1,160 @@
+package com.wafflestudio.webgam.domain.`object`.repository
+
+import com.wafflestudio.webgam.domain.`object`.dto.PageObjectDto.CreateRequest
+import com.wafflestudio.webgam.domain.`object`.model.PageObject
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType
+import com.wafflestudio.webgam.domain.page.model.ProjectPage
+import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldNotContainAnyOf
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@DataJpaTest
+@Import(TestQueryDslConfig::class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Tag("Repository-Test")
+@DisplayName("PageObjectRepository Data JPA 테스트")
+class PageObjectRepositoryImplTest(
+    @Autowired private val userRepository: UserRepository,
+    @Autowired private val projectRepository: ProjectRepository,
+    @Autowired private val projectPageRepository: ProjectPageRepository,
+    @Autowired private val pageObjectRepository: PageObjectRepository,
+) : DescribeSpec() {
+
+    private lateinit var projects: List<Project>
+    private lateinit var pageLists: List<List<ProjectPage>>
+    private lateinit var pageObjectLists: List<List<PageObject>>
+
+    companion object {
+        val projectTitles = listOf("test-project-0", "test-project-1", "test-project-2", "deleted-project")
+        val pageNames = listOf("test-page-0", "test-page-1", "test-page-2", "deleted-page")
+        val objectNames = listOf("object-0", "object-1", "object-2", "object-3", "deleted-object-0", "deleted-object-1")
+    }
+
+    @Transactional
+    override suspend fun beforeSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            val user = userRepository.save(User("test-id", "test-username", "test@email.com", ""))
+            projects = projectTitles.map {
+                val project = Project(user, it)
+                if (it.contains("deleted")) project.delete()
+                projectRepository.save(project)
+            }
+            pageLists = projects.map { p -> pageNames.map {
+                val projectPage = ProjectPage(p, it)
+                if (it.contains("deleted")) projectPage.delete()
+                projectPageRepository.save(projectPage)
+            } }
+            pageObjectLists = pageLists.map { it.map { page -> objectNames.map { name ->
+                val pageObject = PageObject(page, buildRequest(page.id, name))
+                if (name.contains("deleted")) pageObject.delete()
+                pageObjectRepository.save(pageObject)
+            } }.flatten() }
+        }
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            pageObjectRepository.deleteAll()
+            projectPageRepository.deleteAll()
+            projectRepository.deleteAll()
+            userRepository.deleteAll()
+        }
+    }
+
+    fun buildRequest(pageId: Long, objectName: String): CreateRequest = CreateRequest(
+        pageId, objectName, PageObjectType.DEFAULT, 0, 0, 0, 0, 0, null, null, null
+    )
+
+    init {
+        this.describe("findUndeletedPageObjectById 호출될 때") {
+            context("성공적인 경우") {
+                val id = pageObjectLists[0][0].id
+
+                it("삭제 되지 않은 PageObject가 반환된다") {
+                    val pageObject = pageObjectRepository.findUndeletedPageObjectById(id)
+
+                    pageObject shouldNotBe null
+                    pageObject!!.isDeleted shouldBe false
+                }
+            }
+
+            context("해당 id를 갖는 PageObject가 없는 경우") {
+                val id = pageObjectLists[0][0].id + 1000
+
+                it("NULL이 반환된다") {
+                    val pageObject = pageObjectRepository.findUndeletedPageObjectById(id)
+
+                    pageObject shouldBe null
+                }
+            }
+
+            context("해당 id를 갖는 PageObject가 삭제된 경우") {
+                val id = pageObjectLists[0].find { it.isDeleted }!!.id
+
+                it("NULL이 반환된다") {
+                    val pageObject = pageObjectRepository.findUndeletedPageObjectById(id)
+
+                    pageObject shouldBe null
+                }
+            }
+        }
+
+        this.describe("findAllUndeletedPageObjectsInProject 호출될 때") {
+            context("Project ID를 인자로 넣으면") {
+                val project = projects[1]
+                val projectObjects = pageObjectLists[1]
+                val otherProjectObjects = pageObjectLists[2]
+                val deletedProject = projects[3]
+                val deletedProjectObjects = pageObjectLists[3]
+
+                it("해당 프로젝트의 모든 삭제 되지 않은 PageObject들이 반환된다") {
+                    val findObjects = pageObjectRepository.findAllUndeletedPageObjectsInProject(project.id)
+                    val expectedObjectCount = projectObjects.count { !it.isDeleted && !it.page.isDeleted }
+
+                    findObjects.size shouldBe expectedObjectCount
+                    findObjects.forAll { it.isDeleted shouldBe false }
+                }
+
+                it("해당 프로젝트의 삭제된 Page 에 속하는 PageObject는 반환되지 않는다") {
+                    val findObjects = pageObjectRepository.findAllUndeletedPageObjectsInProject(project.id)
+                    val objectsInDeletedPage = projectObjects.filter { it.page.name.contains("deleted") }
+
+                    findObjects shouldNotContainAnyOf objectsInDeletedPage
+                }
+
+                it("다른 프로젝트의 PageObject는 반환되지 않는다") {
+                    val findObjects = pageObjectRepository.findAllUndeletedPageObjectsInProject(project.id)
+
+                    findObjects shouldNotContainAnyOf otherProjectObjects
+                    findObjects shouldNotContainAnyOf deletedProjectObjects
+                }
+
+                it("삭제된 프로젝트인 경우 빈 List가 반환된다") {
+                    val findObjects = pageObjectRepository.findAllUndeletedPageObjectsInProject(deletedProject.id)
+
+                    findObjects.size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/object/service/PageObjectServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/object/service/PageObjectServiceTest.kt
@@ -1,0 +1,231 @@
+package com.wafflestudio.webgam.domain.`object`.service
+
+import com.wafflestudio.webgam.domain.`object`.dto.PageObjectDto.*
+import com.wafflestudio.webgam.domain.`object`.exception.NonAccessiblePageObjectException
+import com.wafflestudio.webgam.domain.`object`.exception.PageObjectNotFoundException
+import com.wafflestudio.webgam.domain.`object`.model.PageObject
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.DEFAULT
+import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
+import com.wafflestudio.webgam.domain.page.exception.NonAccessibleProjectPageException
+import com.wafflestudio.webgam.domain.page.exception.ProjectPageNotFoundException
+import com.wafflestudio.webgam.domain.page.model.ProjectPage
+import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.project.exception.NonAccessibleProjectException
+import com.wafflestudio.webgam.domain.project.exception.ProjectNotFoundException
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Tag
+
+@Tag("Unit-Test")
+@DisplayName("PageObjectService 단위 테스트")
+class PageObjectServiceTest : DescribeSpec() {
+
+    companion object {
+        private val projectRepository = mockk<ProjectRepository>()
+        private val projectPageRepository = mockk<ProjectPageRepository>()
+        private val pageObjectRepository = mockk<PageObjectRepository>()
+        private val pageObjectService = PageObjectService(projectRepository, projectPageRepository, pageObjectRepository)
+        private val project = mockk<Project>()
+        private val nonAccessibleProject = mockk<Project>()
+        private val page = ProjectPage(project, "test-page")
+        private val nonAccessiblePage = mockk<ProjectPage>()
+        private val pageObject = PageObject(page, "test-object", DEFAULT, 0, 0, 0, 0, 0, "", 0, "", null)
+        private val nonAccessiblePageObject = PageObject(nonAccessiblePage, "test-object", DEFAULT, 0, 0, 0, 0, 0, "", 0, "", null)
+        private val deletedPageObject = mockk<PageObject>()
+    }
+
+    override suspend fun beforeSpec(spec: Spec) {
+        every { project.isAccessibleTo(any()) } returns true
+        every { nonAccessibleProject.isAccessibleTo(any()) } returns false
+        every { projectPageRepository.findUndeletedProjectPageById(any()) } returns page
+        every { nonAccessiblePage.isAccessibleTo(any()) } returns false
+        every { nonAccessiblePage.id } returns 100
+        every { deletedPageObject.isDeleted } returns true
+    }
+
+    init {
+        this.describe("listProjectObjects 호출될 때") {
+            context("성공적인 경우") {
+                every { projectRepository.findUndeletedProjectById(any()) } returns project
+                every { pageObjectRepository.findAllUndeletedPageObjectsInProject(any()) } returns listOf(pageObject, nonAccessiblePageObject)
+
+                val response = withContext(Dispatchers.IO) {
+                    pageObjectService.listProjectObjects(1, 1)
+                }
+
+                it("해당 ID를 갖는 프로젝트에 있는 PageObject들이 Detailed Response DTO로 반환된다") {
+                    response.count shouldBe 1
+                    response.data shouldContain DetailedResponse(pageObject)
+                }
+
+                it("접근 불가능한 PageObject들은 제외된다") {
+                    response.data shouldNotContain DetailedResponse(nonAccessiblePageObject)
+                }
+            }
+
+            context("해당 ID를 갖는 프로젝트가 존재하지 않거나 삭제됐으면") {
+                every { projectRepository.findUndeletedProjectById(any()) } returns null
+
+                it("ProjectNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectNotFoundException> { pageObjectService.listProjectObjects(1, 1) }
+                }
+            }
+
+            context("해당 ID를 갖는 프로젝트에 접근할 수 없으면") {
+                every { projectRepository.findUndeletedProjectById(any()) } returns nonAccessibleProject
+
+                it("NonAccessibleProjectException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectException> { pageObjectService.listProjectObjects(1, 1) }
+                }
+            }
+        }
+
+        this.describe("getObject 호출될 때") {
+            context("성공적인 경우") {
+                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns pageObject
+
+                val response = withContext(Dispatchers.IO) {
+                    pageObjectService.getObject(1, 1)
+                }
+
+                it("PageObject가 Detailed Response DTO로 반환된다") {
+                    response shouldBe DetailedResponse(pageObject)
+                }
+            }
+
+            context("해당 ID를 갖는 PageObject가 존재하지 않거나 삭제됐으면") {
+                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns null
+
+                it("PageObjectNotFoundException 예외를 던진다") {
+                    shouldThrow<PageObjectNotFoundException> { pageObjectService.getObject(1, 1) }
+                }
+            }
+
+            context("해당 ID를 갖는 PageObject에 접근할 수 없으면") {
+                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns nonAccessiblePageObject
+
+                it("NonAccessiblePageObjectException 예외를 던진다") {
+                    shouldThrow<NonAccessiblePageObjectException> { pageObjectService.getObject(1, 1) }
+                }
+            }
+        }
+
+        this.describe("createObject 호출될 때") {
+            val request = CreateRequest(0, "", DEFAULT, 0, 0, 0, 0, 0, "", 0, "")
+
+            context("성공적인 경우") {
+                every { projectPageRepository.findUndeletedProjectPageById(any()) } returns page
+                every { pageObjectRepository.save(any()) } returns pageObject
+
+                val response = withContext(Dispatchers.IO) {
+                    pageObjectService.createObject(1, request)
+                }
+
+                it("생성된 PageObject가 SimpleResponse DTO로 반환된다") {
+                    response shouldBe SimpleResponse(pageObject)
+                }
+            }
+
+            context("해당 ID를 갖는 페이지가 존재하지 않거나 삭제됐으면") {
+                every { projectPageRepository.findUndeletedProjectPageById(any()) } returns null
+
+                it("ProjectPageNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectPageNotFoundException> { pageObjectService.createObject(1, request) }
+                }
+            }
+
+            context("해당 ID를 갖는 페이지에 접근할 수 없으면") {
+                every { projectPageRepository.findUndeletedProjectPageById(any()) } returns nonAccessiblePage
+
+                it("NonAccessibleProjectPageException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectPageException> { pageObjectService.createObject(1, request) }
+                }
+            }
+        }
+
+        this.describe("modifyObject 호출될 때") {
+            pageObject.width = 20
+            pageObject.height = 10
+            val request = PatchRequest(null, 30, null, null, null, null, null, null, null)
+
+            context("성공적인 경우") {
+                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns pageObject
+
+                val response = withContext(Dispatchers.IO) {
+                    pageObjectService.modifyObject(1, 1, request)
+                }
+
+                it("수정된 PageObject가 Detailed Response DTO로 반환된다") {
+                    response shouldBe DetailedResponse(pageObject)
+                }
+
+                it("request의 값으로 수정된다") {
+                    response.width shouldBe 30
+                }
+
+                it("request의 NULL은 수정되지 않는다") {
+                    response.height shouldBe 10
+                }
+            }
+
+            context("해당 ID를 갖는 PageObject가 존재하지 않거나 삭제됐으면") {
+                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns null
+
+                it("PageObjectNotFoundException 예외를 던진다") {
+                    shouldThrow<PageObjectNotFoundException> { pageObjectService.modifyObject(1, 1, request) }
+                }
+            }
+
+            context("해당 ID를 갖는 PageObject에 접근할 수 없으면") {
+                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns nonAccessiblePageObject
+
+                it("NonAccessiblePageObjectException 예외를 던진다") {
+                    shouldThrow<NonAccessiblePageObjectException> { pageObjectService.modifyObject(1, 1, request) }
+                }
+            }
+        }
+
+        this.describe("deleteObject 호출될 때") {
+            context("성공적인 경우") {
+                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns pageObject
+
+                it("반환 값이 없으며, 예외도 던지지 않는다") {
+                    shouldNotThrowAny { pageObjectService.deleteObject(1, 1) }
+                }
+
+                it("해당 PageObject의 isDeleted는 true가 된다") {
+                    pageObject.isDeleted shouldBe true
+                }
+            }
+
+            context("해당 ID를 갖는 PageObject가 존재하지 않거나 삭제됐으면") {
+                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns null
+
+                it("PageObjectNotFoundException 예외를 던진다") {
+                    shouldThrow<PageObjectNotFoundException> { pageObjectService.deleteObject(1, 1) }
+                }
+            }
+
+            context("해당 ID를 갖는 PageObject에 접근할 수 없으면") {
+                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns nonAccessiblePageObject
+
+                it("NonAccessiblePageObjectException 예외를 던진다") {
+                    shouldThrow<NonAccessiblePageObjectException> { pageObjectService.deleteObject(1, 1) }
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepositoryImplTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepositoryImplTest.kt
@@ -1,0 +1,103 @@
+package com.wafflestudio.webgam.domain.page.repository
+
+import com.wafflestudio.webgam.domain.page.model.ProjectPage
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@DataJpaTest
+@Import(TestQueryDslConfig::class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Tag("Repository-Test")
+@DisplayName("ProjectPageRepository Data JPA 테스트")
+class ProjectPageRepositoryImplTest(
+    @Autowired private val userRepository: UserRepository,
+    @Autowired private val projectRepository: ProjectRepository,
+    @Autowired private val projectPageRepository: ProjectPageRepository,
+) : DescribeSpec() {
+
+    private lateinit var projects: List<Project>
+    private lateinit var pageLists: List<List<ProjectPage>>
+
+    companion object {
+        val projectTitles = listOf("test-project-0", "test-project-1", "test-project-2", "deleted-project")
+        val pageNames = listOf("test-page-0", "test-page-1", "test-page-2", "deleted-page")
+    }
+
+    @Transactional
+    override suspend fun beforeSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            val user = userRepository.save(User("test-id", "test-username", "test@email.com", ""))
+            projects = projectTitles.map {
+                val project = Project(user, it)
+                if (it.contains("deleted")) project.delete()
+                projectRepository.save(project)
+            }
+            pageLists = projects.map { p -> pageNames.map {
+                val projectPage = ProjectPage(p, it)
+                if (it.contains("deleted")) projectPage.delete()
+                projectPageRepository.save(projectPage)
+            } }
+        }
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            projectPageRepository.deleteAll()
+            projectRepository.deleteAll()
+            userRepository.deleteAll()
+        }
+    }
+
+    init {
+        this.describe("findUndeletedProjectPageById 호출될 때") {
+            context("성공적인 경우") {
+                val id = pageLists[0][0].id
+
+                it("삭제 되지 않은 ProjectPage가 반환된다") {
+                    val projectPage = projectPageRepository.findUndeletedProjectPageById(id)
+
+                    projectPage shouldNotBe null
+                    projectPage!!.isDeleted shouldBe false
+                }
+            }
+
+            context("해당 id를 갖는 ProjectPage가 없는 경우") {
+                val id = pageLists[0][0].id + 1000
+
+                it("NULL이 반환된다") {
+                    val projectPage = projectPageRepository.findUndeletedProjectPageById(id)
+
+                    projectPage shouldBe  null
+                }
+            }
+
+            context("해당 id를 갖는 ProjectPage가 삭제된 경우") {
+                val id = pageLists[0].find { it.isDeleted }!!.id
+
+                it("NULL이 반환된다") {
+                    val projectPage = projectPageRepository.findUndeletedProjectPageById(id)
+
+                    projectPage shouldBe  null
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryImplTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryImplTest.kt
@@ -1,0 +1,92 @@
+package com.wafflestudio.webgam.domain.project.repository
+
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@DataJpaTest
+@Import(TestQueryDslConfig::class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Tag("Repository-Test")
+@DisplayName("ProjectRepository Data JPA 테스트")
+class ProjectRepositoryImplTest(
+    @Autowired private val userRepository: UserRepository,
+    @Autowired private val projectRepository: ProjectRepository,
+) : DescribeSpec() {
+
+    private lateinit var projects: List<Project>
+
+    companion object {
+        val projectTitles = listOf("test-project-0", "test-project-1", "test-project-2", "deleted-project")
+    }
+
+    @Transactional
+    override suspend fun beforeSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            val user = userRepository.save(User("test-id", "test-username", "test@email.com", ""))
+            projects = projectTitles.map {
+                val project = Project(user, it)
+                if (it.contains("deleted")) project.delete()
+                projectRepository.save(project)
+            }
+        }
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            projectRepository.deleteAll()
+            userRepository.deleteAll()
+        }
+    }
+
+    init {
+        this.describe("findUndeletedProjectById 호출될 때") {
+            context("성공적인 경우") {
+                val id = projects[0].id
+
+                it("삭제 되지 않은 Project가 반환된다") {
+                    val project = projectRepository.findUndeletedProjectById(id)
+
+                    project shouldNotBe null
+                    project!!.isDeleted shouldBe false
+                }
+            }
+
+            context("해당 id를 갖는 Project가 없는 경우") {
+                val id = projects[0].id + 1000
+
+                it("NULL이 반환된다") {
+                    val project = projectRepository.findUndeletedProjectById(id)
+
+                    project shouldBe  null
+                }
+            }
+
+            context("해당 id를 갖는 Project가 삭제된 경우") {
+                val id = projects.find { it.isDeleted }!!.id
+
+                it("NULL이 반환된다") {
+                    val project = projectRepository.findUndeletedProjectById(id)
+
+                    project shouldBe  null
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/global/config/TestQueryDslConfig.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/global/config/TestQueryDslConfig.kt
@@ -1,0 +1,19 @@
+package com.wafflestudio.webgam.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class TestQueryDslConfig {
+
+    @PersistenceContext
+    lateinit var entityManager: EntityManager
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}


### PR DESCRIPTION
CRUD API 개발, 테스트까지 완료했습니다.
Object가 아니더라도 관련된 Project, Page 기능도 조금 개발하였습니다.

이번 PR에 대해서 간략하게 말씀을 드리자면,
- QueryDsl 라이브러리 추가 (N+1 문제 해결 겸, 삭제된 엔티티 결과에서 제외하기 위해)
  - projectRepository, projectPageRepository, objectRepository 모두 QueryDsl로 구현하였습니다.
  - SQL과 크게 다를 게 없어서 이 부분도 코드 보시면 어렵지 않게 사용하실 수 있을 겁니다.
- ErrorCode를 도메인 별로 100씩 분할해서 겹치지 않게 했습니다.
- `BaseTimeTraceLazyDeletedEntity`에 delete 함수를 추가했습니다. 지금은 컴파일 에러가 나지 않게 open으로 했지만 추후에 abstract로 바꾸어야 할 것 같습니다. delete 함수의 용도는, 하위 엔티티까지 한번에 제거하기 위해서입니다.
  -  예) project 객체에서 delete가 호출되면 하위 page, object, event 모두 삭제가 되게끔
- Object API 개발, 테스트, 도큐먼트 완료
