### PR TITLE
Feature/11,12,19 bugfix

### DIFF
--- a/.github/workflows/webgam-dev-cd.yaml
+++ b/.github/workflows/webgam-dev-cd.yaml
@@ -25,11 +25,6 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Set up MySQL
-        run: |
-          sudo service mysql start
-          mysql -uroot -proot < ./scripts/sql/test_db_init.sql
-
       - name: Grant execution permission
         run: chmod +x ./gradlew
 

--- a/.github/workflows/webgam-gradle-ci.yaml
+++ b/.github/workflows/webgam-gradle-ci.yaml
@@ -24,11 +24,6 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Set up MySQL
-        run: |
-          sudo service mysql start
-          mysql -uroot -proot < ./scripts/sql/test_db_init.sql
-
       - name: Grant execution permission
         run: chmod +x ./gradlew
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
 	testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
 	testImplementation("io.mockk:mockk:1.13.2")
 	testImplementation("com.ninja-squad:springmockk:4.0.0")
+	testImplementation("com.h2database:h2:2.1.214")
 }
 
 tasks.withType<KotlinCompile> {

--- a/scripts/sql/test_db_init.sql
+++ b/scripts/sql/test_db_init.sql
@@ -1,3 +1,0 @@
-CREATE DATABASE webgam_db_test;
-CREATE USER 'webgam_admin'@'localhost' IDENTIFIED BY 'WEBGAM_admin_01';
-GRANT ALL PRIVILEGES ON webgam_db_test.* TO 'webgam_admin'@'localhost';

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -8,9 +8,6 @@ include::{snippets}/signup/200/http-request.adoc[]
 include::{snippets}/signup/200/request-fields.adoc[]
 .Response
 include::{snippets}/signup/200/http-response.adoc[]
-.Error Response
-include::{snippets}/signup/400-0001/http-response.adoc[]
-include::{snippets}/signup/409-9001/http-response.adoc[]
 ====
 
 === Auth: 로그인
@@ -21,8 +18,6 @@ include::{snippets}/login/200/http-request.adoc[]
 include::{snippets}/login/200/request-fields.adoc[]
 .Response
 include::{snippets}/login/200/http-response.adoc[]
-.Error Response
-include::{snippets}/login/401-1001/http-response.adoc[]
 ====
 
 === Auth: 토큰 재발급
@@ -35,9 +30,6 @@ include::{snippets}/refresh/200/http-request.adoc[]
 include::{snippets}/refresh/200/request-cookies.adoc[]
 .Response
 include::{snippets}/refresh/200/http-response.adoc[]
-.Error Response
-include::{snippets}/refresh/400-0002-no-cookie/http-response.adoc[]
-include::{snippets}/refresh/401-1002/http-response.adoc[]
 ====
 
 === Auth: 로그아웃
@@ -48,4 +40,18 @@ include::{snippets}/refresh/401-1002/http-response.adoc[]
 include::{snippets}/logout/200/http-request.adoc[]
 .Response
 include::{snippets}/logout/200/http-response.adoc[]
+====
+
+=== Error Response
+.로그인 아이디가 존재하지 않거나, 비밀번호가 틀린 경우
+====
+include::{snippets}/error/auth/4/http-response.adoc[]
+====
+.회원가입할 때, 이미 아이디를 다른 사용자가 사용하고 있는 경우
+====
+include::{snippets}/error/auth/5/http-response.adoc[]
+====
+.토큰 재발급할 때, 쿠키에 토큰이 없는 경우
+====
+include::{snippets}/error/auth/6/http-response.adoc[]
 ====

--- a/src/docs/asciidoc/event.adoc
+++ b/src/docs/asciidoc/event.adoc
@@ -50,4 +50,6 @@ include::{snippets}/error/event/1/http-response.adoc[]
 include::{snippets}/error/event/2/http-response.adoc[]
 .이벤트를 생성할 때, 기존 오브젝트에 이미 이벤트가 할당되어 있는 경우
 include::{snippets}/error/event/3/http-response.adoc[]
+.이벤트를 생성하거나 수정할 때, 다음 페이지가 같은 프로젝트 내에 없는 경우
+include::{snippets}/error/event/4/http-response.adoc[]
 ====

--- a/src/docs/asciidoc/general.adoc
+++ b/src/docs/asciidoc/general.adoc
@@ -1,0 +1,58 @@
+[[General]]
+== 공통
+
+=== Ping API
+서버 상태 확인 용도로, 토큰이 필요하지 않습니다.
+====
+.Request
+include::{snippets}/ping/200/http-request.adoc[]
+.Response
+include::{snippets}/ping/200/http-response.adoc[]
+====
+
+=== Auth-Ping API
+인증 확인 용도로, 토큰이 필요합니다.
+====
+.Request
+include::{snippets}/auth-ping/200/http-request.adoc[]
+.Response
+include::{snippets}/auth-ping/200/http-response.adoc[]
+====
+
+
+=== 인증 관련 Error Response
+.토큰이 없는 경우
+====
+include::{snippets}/error/auth/1/http-response.adoc[]
+====
+.토큰이 유효하지 않는 경우
+====
+`detail` 은 달라질 수 있습니다.
+include::{snippets}/error/auth/2/http-response.adoc[]
+====
+.토큰이 유효하지만, 해당 API나 리소스에 접근 권한 없는 경우
+====
+보통의 경우, 잘못된 API 경로나 Http Method 오류 가능성이 높습니다.
+include::{snippets}/error/auth/3/http-response.adoc[]
+====
+
+
+=== 공통 Error Response
+.Request Body에 올바르지 않은 값이 들어갈 경우
+====
+`detail` 을 참고해주세요
+include::{snippets}/error/common/1/http-response.adoc[]
+====
+.Path Variable, Request Parameter에 올바르지 않은 값이 들어갈 경우
+====
+`detail` 을 참고해주세요
+include::{snippets}/error/common/2/http-response.adoc[]
+====
+.Request Body에 올바르지 않은 타입이 들어갈 경우
+====
+include::{snippets}/error/common/3/http-response.adoc[]
+====
+.Request Parameter에 올바르지 않은 타입이 들어갈 경우
+====
+include::{snippets}/error/common/4/http-response.adoc[]
+====

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -6,45 +6,7 @@
 :toclevels: 2
 :sectlinks:
 
-[[General]]
-== 공통
-
-=== Ping API
-서버 상태 확인 용도로, 토큰이 필요하지 않습니다.
-====
-.Request
-include::{snippets}/ping/200/http-request.adoc[]
-.Response
-include::{snippets}/ping/200/http-response.adoc[]
-====
-
-=== Auth-Ping API
-인증 확인 용도로, 토큰이 필요합니다.
-====
-.Request
-include::{snippets}/auth-ping/200/http-request.adoc[]
-.Response
-include::{snippets}/auth-ping/200/http-response.adoc[]
-====
-
-
-=== 인증 관련 Error Response
-.토큰이 없는 경우
-====
-include::{snippets}/auth-ping/401-1000/http-response.adoc[]
-====
-.토큰이 유효하지 않는 경우
-====
-`detail` 은 달라질 수 있습니다.
-include::{snippets}/auth-ping/401-1002/http-response.adoc[]
-====
-.토큰이 유효하지만, 해당 API나 리소스에 접근 권한 없는 경우
-====
-보통의 경우, 잘못된 API 경로나 Http Method 오류 가능성이 높습니다.
-include::{snippets}/auth-ping/403-3001/http-response.adoc[]
-====
-
-
+include::general.adoc[]
 include::auth.adoc[]
 include::user.adoc[]
 include::project.adoc[]

--- a/src/docs/asciidoc/object.adoc
+++ b/src/docs/asciidoc/object.adoc
@@ -3,73 +3,59 @@
 === 프로젝트 내 모든 오브젝트 조회하기
 ====
 .Request
-include::{snippets}/get-project-objects/200/http-request.adoc[]
+include::{snippets}/object/get-list/http-request.adoc[]
 .Query Parameter
-include::{snippets}/get-project-objects/200/query-parameters.adoc[]
+include::{snippets}/object/get-list/query-parameters.adoc[]
 .Response
-include::{snippets}/get-project-objects/200/http-response.adoc[]
-.Error Response
-include::{snippets}/get-project-objects/400-0/http-response.adoc[]
-include::{snippets}/get-project-objects/403-0/http-response.adoc[]
-include::{snippets}/get-project-objects/404-0/http-response.adoc[]
+include::{snippets}/object/get-list/http-response.adoc[]
 ====
 
 === 오브젝트 생성하기
 ====
 .Request
-include::{snippets}/create-object/200/http-request.adoc[]
+include::{snippets}/object/create/http-request.adoc[]
 .Request Body
-include::{snippets}/create-object/200/request-fields.adoc[]
+include::{snippets}/object/create/request-fields.adoc[]
 .Response
-include::{snippets}/create-object/200/http-response.adoc[]
-.Error Response
-include::{snippets}/create-object/400-0/http-response.adoc[]
-include::{snippets}/create-object/400-1/http-response.adoc[]
-include::{snippets}/create-object/403-0/http-response.adoc[]
-include::{snippets}/create-object/404-0/http-response.adoc[]
+include::{snippets}/object/create/http-response.adoc[]
 ====
 
 === 오브젝트 조회하기
 ====
 .Request
-include::{snippets}/get-object/200/http-request.adoc[]
+include::{snippets}/object/get/http-request.adoc[]
 .Path Parameter
-include::{snippets}/get-object/200/path-parameters.adoc[]
+include::{snippets}/object/get/path-parameters.adoc[]
 .Response
-include::{snippets}/get-object/200/http-response.adoc[]
-.Error Response
-include::{snippets}/get-object/400-0/http-response.adoc[]
-include::{snippets}/get-object/403-0/http-response.adoc[]
-include::{snippets}/get-object/404-0/http-response.adoc[]
+include::{snippets}/object/get/http-response.adoc[]
 ====
 
 === 오브젝트 수정하기
 ====
 .Request
-include::{snippets}/patch-object/200/http-request.adoc[]
+include::{snippets}/object/patch/http-request.adoc[]
 .Path Parameter
-include::{snippets}/patch-object/200/path-parameters.adoc[]
+include::{snippets}/object/patch/path-parameters.adoc[]
 .Request Body
-include::{snippets}/patch-object/200/request-fields.adoc[]
+include::{snippets}/object/patch/request-fields.adoc[]
 .Response
-include::{snippets}/patch-object/200/http-response.adoc[]
-.Error Response
-include::{snippets}/patch-object/400-0/http-response.adoc[]
-include::{snippets}/patch-object/400-1/http-response.adoc[]
-include::{snippets}/patch-object/403-0/http-response.adoc[]
-include::{snippets}/patch-object/404-0/http-response.adoc[]
+include::{snippets}/object/patch/http-response.adoc[]
 ====
 
 === 오브젝트 삭제하기
 ====
 .Request
-include::{snippets}/delete-object/200/http-request.adoc[]
+include::{snippets}/object/delete/http-request.adoc[]
 .Path Parameter
-include::{snippets}/delete-object/200/path-parameters.adoc[]
+include::{snippets}/object/delete/path-parameters.adoc[]
 .Response
-include::{snippets}/delete-object/200/http-response.adoc[]
-.Error Response
-include::{snippets}/delete-object/400-0/http-response.adoc[]
-include::{snippets}/delete-object/403-0/http-response.adoc[]
-include::{snippets}/delete-object/404-0/http-response.adoc[]
+include::{snippets}/object/delete/http-response.adoc[]
+====
+
+=== Error Response
+====
+.오브젝트가 삭제되거나 존재하지 않을 때
+include::{snippets}/error/object/1/http-response.adoc[]
+.오브젝트에 접근 권한이 없는 경우
+include::{snippets}/error/object/2/http-response.adoc[]
 ====

--- a/src/docs/asciidoc/page.adoc
+++ b/src/docs/asciidoc/page.adoc
@@ -3,58 +3,49 @@
 === 페이지 조회하기
 ====
 .Request
-include::{snippets}/get-project-page/200/http-request.adoc[]
+include::{snippets}/page/get/http-request.adoc[]
 .Path Parameter
-include::{snippets}/get-project-page/200/path-parameters.adoc[]
+include::{snippets}/page/get/path-parameters.adoc[]
 .Response
-include::{snippets}/get-project-page/200/http-response.adoc[]
-.Error Response
-include::{snippets}/get-project-page/400-0/http-response.adoc[]
-include::{snippets}/get-project-page/403-0/http-response.adoc[]
-include::{snippets}/get-project-page/404-0/http-response.adoc[]
+include::{snippets}/page/get/http-response.adoc[]
 ====
 
 === 페이지 생성하기
 ====
 .Request
-include::{snippets}/create-project-page/200/http-request.adoc[]
+include::{snippets}/page/create/http-request.adoc[]
 .Request Body
-include::{snippets}/create-project-page/200/request-fields.adoc[]
+include::{snippets}/page/create/request-fields.adoc[]
 .Response
-include::{snippets}/create-project-page/200/http-response.adoc[]
-.Error Response
-include::{snippets}/create-project-page/400-0/http-response.adoc[]
-include::{snippets}/create-project-page/400-1/http-response.adoc[]
-include::{snippets}/create-project-page/403-0/http-response.adoc[]
-include::{snippets}/create-project-page/404-0/http-response.adoc[]
+include::{snippets}/page/create/http-response.adoc[]
 ====
 
 === 페이지 수정하기
 ====
 .Request
-include::{snippets}/patch-project-page/200/http-request.adoc[]
+include::{snippets}/page/patch/http-request.adoc[]
 .Path Parameter
-include::{snippets}/patch-project-page/200/path-parameters.adoc[]
+include::{snippets}/page/patch/path-parameters.adoc[]
 .Request Body
-include::{snippets}/patch-project-page/200/request-fields.adoc[]
+include::{snippets}/page/patch/request-fields.adoc[]
 .Response
-include::{snippets}/patch-project-page/200/http-response.adoc[]
-.Error Response
-include::{snippets}/patch-project-page/400-0/http-response.adoc[]
-include::{snippets}/patch-project-page/403-0/http-response.adoc[]
-include::{snippets}/patch-project-page/404-0/http-response.adoc[]
+include::{snippets}/page/patch/http-response.adoc[]
 ====
 
 === 페이지 삭제하기
 ====
 .Request
-include::{snippets}/delete-project-page/200/http-request.adoc[]
+include::{snippets}/page/delete/http-request.adoc[]
 .Path Parameter
-include::{snippets}/delete-project-page/200/path-parameters.adoc[]
+include::{snippets}/page/delete/path-parameters.adoc[]
 .Response
-include::{snippets}/delete-project-page/200/http-response.adoc[]
-.Error Response
-include::{snippets}/delete-project-page/400-0/http-response.adoc[]
-include::{snippets}/delete-project-page/403-0/http-response.adoc[]
-include::{snippets}/delete-project-page/404-0/http-response.adoc[]
+include::{snippets}/page/delete/http-response.adoc[]
+====
+
+=== Error Response
+====
+.페이지가 삭제되거나 존재하지 않을 때
+include::{snippets}/error/page/1/http-response.adoc[]
+.페이지에 접근 권한이 없는 경우
+include::{snippets}/error/page/2/http-response.adoc[]
 ====

--- a/src/docs/asciidoc/project.adoc
+++ b/src/docs/asciidoc/project.adoc
@@ -3,74 +3,67 @@
 === 프로젝트 조회하기
 ====
 .Request
-include::{snippets}/get-project/200/http-request.adoc[]
+include::{snippets}/project/get/http-request.adoc[]
 .Path Parameter
-include::{snippets}/get-project/200/path-parameters.adoc[]
+include::{snippets}/project/get/path-parameters.adoc[]
 .Response
-include::{snippets}/get-project/200/http-response.adoc[]
-.Error Response
-include::{snippets}/get-project/400-0/http-response.adoc[]
-include::{snippets}/get-project/403-0/http-response.adoc[]
-include::{snippets}/get-project/404-0/http-response.adoc[]
+include::{snippets}/project/get/http-response.adoc[]
 ====
 
 === 모든 프로젝트 조회하기
 ====
 .Request
-include::{snippets}/get-projects/200/http-request.adoc[]
+include::{snippets}/project/get-list/http-request.adoc[]
 .Query Parameter
-include::{snippets}/get-projects/200/query-parameters.adoc[]
+include::{snippets}/project/get-list/query-parameters.adoc[]
 .Response
-include::{snippets}/get-projects/200/http-response.adoc[]
+include::{snippets}/project/get-list/http-response.adoc[]
 ====
 
 === 나의 모든 프로젝트 조회하기
 ====
 .Request
-include::{snippets}/get-my-projects/200/http-request.adoc[]
+include::{snippets}/project/get-user-list/http-request.adoc[]
 .Response
-include::{snippets}/get-my-projects/200/http-response.adoc[]
+include::{snippets}/project/get-user-list/http-response.adoc[]
 ====
 
 === 프로젝트 생성하기
 ====
 .Request
-include::{snippets}/create-project/200/http-request.adoc[]
+include::{snippets}/project/create/http-request.adoc[]
 .Request Body
-include::{snippets}/create-project/200/request-fields.adoc[]
+include::{snippets}/project/create/request-fields.adoc[]
 .Response
-include::{snippets}/create-project/200/http-response.adoc[]
-.Error Response
-include::{snippets}/create-project/400-0/http-response.adoc[]
+include::{snippets}/project/create/http-response.adoc[]
 ====
 
 === 프로젝트 수정하기
 ====
 .Request
-include::{snippets}/patch-project/200/http-request.adoc[]
+include::{snippets}/project/patch/http-request.adoc[]
 .Path Parameter
-include::{snippets}/patch-project/200/path-parameters.adoc[]
+include::{snippets}/project/patch/path-parameters.adoc[]
 .Request Body
-include::{snippets}/patch-project/200/request-fields.adoc[]
+include::{snippets}/project/patch/request-fields.adoc[]
 .Response
-include::{snippets}/patch-project/200/http-response.adoc[]
-.Error Response
-include::{snippets}/patch-project/400-0/http-response.adoc[]
-include::{snippets}/patch-project/400-1/http-response.adoc[]
-include::{snippets}/patch-project/403-0/http-response.adoc[]
-include::{snippets}/patch-project/404-0/http-response.adoc[]
+include::{snippets}/project/patch/http-response.adoc[]
 ====
 
 === 프로젝트 삭제하기
 ====
 .Request
-include::{snippets}/delete-project/200/http-request.adoc[]
+include::{snippets}/project/delete/http-request.adoc[]
 .Path Parameter
-include::{snippets}/delete-project/200/path-parameters.adoc[]
+include::{snippets}/project/delete/path-parameters.adoc[]
 .Response
-include::{snippets}/delete-project/200/http-response.adoc[]
-.Error Response
-include::{snippets}/delete-project/400-0/http-response.adoc[]
-include::{snippets}/delete-project/403-0/http-response.adoc[]
-include::{snippets}/delete-project/404-0/http-response.adoc[]
+include::{snippets}/project/delete/http-response.adoc[]
+====
+
+=== Error Response
+====
+.프로젝트가 삭제되거나 존재하지 않을 때
+include::{snippets}/error/project/1/http-response.adoc[]
+.프로젝트에 접근 권한이 없는 경우
+include::{snippets}/error/project/2/http-response.adoc[]
 ====

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/event/dto/ObjectEventDto.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/event/dto/ObjectEventDto.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.webgam.domain.event.dto
 import com.wafflestudio.webgam.domain.event.model.ObjectEvent
 import com.wafflestudio.webgam.domain.event.model.TransitionType
 import com.wafflestudio.webgam.domain.event.model.TransitionType.DEFAULT
+import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto
 import com.wafflestudio.webgam.global.common.dto.TimeTraceEntityDto
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
@@ -31,6 +32,7 @@ class ObjectEventDto {
         override val modifiedAt: LocalDateTime,
         override val modifiedBy: String,
         val transitionType: TransitionType,
+        val nextPage: ProjectPageDto.SimpleResponse?,
     ): TimeTraceEntityDto.Response(id, createdAt, createdBy, modifiedAt, modifiedBy) {
         constructor(objectEvent: ObjectEvent): this(
             id = objectEvent.id,
@@ -39,6 +41,7 @@ class ObjectEventDto {
             modifiedAt = objectEvent.modifiedAt,
             modifiedBy = objectEvent.modifiedBy,
             transitionType = objectEvent.transitionType,
+            nextPage = objectEvent.nextPage?.let { ProjectPageDto.SimpleResponse(it) },
         )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/event/exception/LinkNonRelatedPageException.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/event/exception/LinkNonRelatedPageException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.webgam.domain.event.exception
+
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.PAGE_IN_OTHER_PROJECT
+import com.wafflestudio.webgam.global.common.exception.WebgamException
+
+class LinkNonRelatedPageException(id: Long): WebgamException.BadRequest(PAGE_IN_OTHER_PROJECT,
+    "Page with id $id is in other project, you can not link this page.")

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/event/model/ObjectEvent.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/event/model/ObjectEvent.kt
@@ -36,6 +36,7 @@ class ObjectEvent(
 
     override fun delete() {
         isDeleted = true
+        `object`.event = null
         `object`.deletedEvents.add(this)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/event/model/ObjectEvent.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/event/model/ObjectEvent.kt
@@ -30,13 +30,11 @@ class ObjectEvent(
         nextPage = nextPage,
         transitionType = createRequest.transitionType,
     ) {
-        `object`.event = this
+        `object`.events.add(this)
         nextPage?.triggeredEvents?.add(this)
     }
 
     override fun delete() {
         isDeleted = true
-        `object`.event = null
-        `object`.deletedEvents.add(this)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/event/service/ObjectEventService.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/event/service/ObjectEventService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.webgam.domain.event.service
 
 import com.wafflestudio.webgam.domain.event.dto.ObjectEventDto.*
+import com.wafflestudio.webgam.domain.event.exception.LinkNonRelatedPageException
 import com.wafflestudio.webgam.domain.event.exception.MultipleEventAllocationException
 import com.wafflestudio.webgam.domain.event.exception.NonAccessibleObjectEventException
 import com.wafflestudio.webgam.domain.event.exception.ObjectEventNotFoundException
@@ -40,6 +41,9 @@ class ObjectEventService(
         val nextPage = request.nextPageId?.let {
             val page = projectPageRepository.findUndeletedProjectPageById(it) ?: throw ProjectPageNotFoundException(request.nextPageId)
             if (!page.isAccessibleTo(myId)) throw NonAccessibleProjectPageException(request.nextPageId)
+
+            if (page.project != pageObject.page.project) throw LinkNonRelatedPageException(request.nextPageId)
+
             page
         }
 
@@ -57,6 +61,9 @@ class ObjectEventService(
         request.nextPageId?.let {
             val page = projectPageRepository.findUndeletedProjectPageById(it) ?: throw ProjectPageNotFoundException(request.nextPageId)
             if (!page.isAccessibleTo(myId)) throw NonAccessibleProjectPageException(request.nextPageId)
+
+            if (page.project != event.`object`.page.project) throw LinkNonRelatedPageException(request.nextPageId)
+
             event.nextPage = page
             page.triggeredEvents.add(event)
         }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/event/service/ObjectEventService.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/event/service/ObjectEventService.kt
@@ -36,7 +36,7 @@ class ObjectEventService(
             .findUndeletedPageObjectById(request.objectId!!) ?: throw PageObjectNotFoundException(request.objectId)
         if (!pageObject.isAccessibleTo(myId)) throw NonAccessiblePageObjectException(request.objectId)
 
-        pageObject.event ?.let { throw MultipleEventAllocationException(pageObject.id) }
+        pageObject.event ?.let { throw MultipleEventAllocationException(request.objectId) }
 
         val nextPage = request.nextPageId?.let {
             val page = projectPageRepository.findUndeletedProjectPageById(it) ?: throw ProjectPageNotFoundException(request.nextPageId)

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/model/PageObject.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/model/PageObject.kt
@@ -34,13 +34,10 @@ class PageObject(
 
     var imageSource: String?,
 
-    @OneToOne(fetch = FetchType.LAZY)
-    var event: ObjectEvent?,
-
     /* From Here: Not saved in DB */
 
     @OneToMany(mappedBy = "object", orphanRemoval = true, cascade = [CascadeType.ALL])
-    val deletedEvents: MutableList<ObjectEvent> = mutableListOf(),
+    val events: MutableList<ObjectEvent> = mutableListOf(),
 
     ): BaseTimeTraceLazyDeletedEntity(), WebgamAccessModel {
     override fun isAccessibleTo(currentUserId: Long): Boolean {
@@ -59,10 +56,13 @@ class PageObject(
         textContent = createRequest.textContent,
         fontSize = createRequest.fontSize,
         imageSource = createRequest.imageSource,
-        event = null
     ) {
         page.objects.add(this)
     }
+
+    @get:Transient
+    val event: ObjectEvent?
+        get() = events.firstOrNull { !it.isDeleted }
 
     override fun delete() {
         isDeleted = true

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/model/PageObject.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/model/PageObject.kt
@@ -11,7 +11,7 @@ import jakarta.persistence.*
 @Table(name = "page_object")
 class PageObject(
     @ManyToOne(fetch = FetchType.LAZY)
-    var page: ProjectPage,
+    val page: ProjectPage,
 
     var name: String,
 
@@ -66,10 +66,6 @@ class PageObject(
 
     override fun delete() {
         isDeleted = true
-        event?.let {
-            it.delete()
-            this.event = null
-            deletedEvents.add(it)
-        }
+        event?.delete()
     }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepositoryImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/object/repository/PageObjectRepositoryImpl.kt
@@ -17,28 +17,25 @@ class PageObjectRepositoryImpl(
 
     fun id(id: Long): BooleanExpression = pageObject.id.eq(id)
     fun undeletedPageObject(): BooleanExpression = pageObject.isDeleted.isFalse
-    fun undeletedProjectPage(): BooleanExpression = projectPage.isDeleted.isFalse
-    fun undeletedProject(): BooleanExpression = project.isDeleted.isFalse
-    fun undeletedUser(): BooleanExpression = user.isDeleted.isFalse
 
     override fun findUndeletedPageObjectById(id: Long): PageObject? = jpaQueryFactory
         .select(pageObject)
         .from(pageObject)
         .leftJoin(pageObject.page, projectPage).fetchJoin()
-        .leftJoin(pageObject.event, objectEvent).fetchJoin()
+        .leftJoin(pageObject.events, objectEvent).fetchJoin()
         .leftJoin(projectPage.project, project).fetchJoin()
         .leftJoin(project.owner, user).fetchJoin()
-        .where(id(id), undeletedPageObject(), undeletedProjectPage(), undeletedProject(), undeletedUser())
+        .where(id(id), undeletedPageObject())
         .fetchOne()
 
     override fun findAllUndeletedPageObjectsInProject(projectId: Long): List<PageObject> = jpaQueryFactory
         .select(pageObject)
         .from(pageObject)
         .leftJoin(pageObject.page, projectPage).fetchJoin()
-        .leftJoin(pageObject.event, objectEvent).fetchJoin()
+        .leftJoin(pageObject.events, objectEvent).fetchJoin()
         .leftJoin(projectPage.project, project).fetchJoin()
         .leftJoin(project.owner, user).fetchJoin()
-        .where(project.id.eq(projectId), undeletedPageObject(), undeletedProjectPage(), undeletedProject(), undeletedUser())
+        .where(project.id.eq(projectId), undeletedPageObject())
         .fetch()
 
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/controller/ProjectPageController.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/controller/ProjectPageController.kt
@@ -1,12 +1,7 @@
 package com.wafflestudio.webgam.domain.page.controller
 
+import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.*
 import com.wafflestudio.webgam.domain.page.service.ProjectPageService
-import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.DetailedResponse
-import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.SimpleResponse
-import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.CreateRequest
-import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.PatchRequest
-import com.wafflestudio.webgam.domain.project.service.ProjectService
-import com.wafflestudio.webgam.global.common.dto.ListResponse
 import com.wafflestudio.webgam.global.security.CurrentUser
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
@@ -57,9 +52,9 @@ class ProjectPageController (
             @CurrentUser myId: Long,
             @PathVariable("id") @Positive id: Long
     )
-    : ResponseEntity<SimpleResponse> {
-        val projectPage = projectPageService.deleteProjectPage(myId, id)
-        return ResponseEntity.ok(projectPage)
+    : ResponseEntity<Any> {
+        projectPageService.deleteProjectPage(myId, id)
+        return ResponseEntity.ok().build()
     }
 
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/controller/ProjectPageController.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/controller/ProjectPageController.kt
@@ -18,17 +18,17 @@ class ProjectPageController (
     @GetMapping("/{id}")
     fun getProjectPageInfo(
             @CurrentUser myId:Long,
-            @PathVariable("id") @Positive projectId: Long
+            @PathVariable("id") @Positive pageId: Long
     )
     : ResponseEntity<DetailedResponse> {
-        val projectPage = projectPageService.getProjectPage(myId, projectId)
+        val projectPage = projectPageService.getProjectPage(myId, pageId)
         return ResponseEntity.ok(projectPage)
     }
 
     //TODO get all pages in project?
 
 
-    @PostMapping("")
+    @PostMapping
     fun createProjectPage(
             @CurrentUser myId: Long,
             @RequestBody @Valid request: CreateRequest

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/controller/ProjectPageController.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/controller/ProjectPageController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*
 
 @Validated
 @RestController
-@RequestMapping("/api/v1/page")
+@RequestMapping("/api/v1/pages")
 class ProjectPageController (
         private val projectPageService: ProjectPageService,
 ){

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/dto/ProjectPageDto.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/dto/ProjectPageDto.kt
@@ -5,12 +5,13 @@ import com.wafflestudio.webgam.domain.page.model.ProjectPage
 import com.wafflestudio.webgam.global.common.dto.TimeTraceEntityDto
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
 import java.time.LocalDateTime
 
 class ProjectPageDto {
     data class CreateRequest(
-        @field:NotNull
-        val projectId: Long,
+        @field:[NotNull Positive]
+        val projectId: Long?,
         @field:NotBlank
         val name: String?,
     )

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/model/ProjectPage.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/model/ProjectPage.kt
@@ -18,7 +18,7 @@ class ProjectPage(
 
     /* From Here: Not saved in DB */
 
-    @OneToMany(mappedBy = "page")
+    @OneToMany(mappedBy = "page", orphanRemoval = true, cascade = [CascadeType.ALL])
     val objects: MutableList<PageObject> = mutableListOf(),
 
     @OneToMany(mappedBy = "nextPage")
@@ -35,5 +35,11 @@ class ProjectPage(
         name = createRequest.name!!,
     ) {
         project.pages.add(this)
+    }
+
+    override fun delete() {
+        isDeleted = true
+        objects.forEach { it.delete() }
+        triggeredEvents.forEach { it.nextPage = null }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/model/ProjectPage.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/model/ProjectPage.kt
@@ -40,6 +40,5 @@ class ProjectPage(
     override fun delete() {
         isDeleted = true
         objects.forEach { it.delete() }
-        triggeredEvents.forEach { it.nextPage = null }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageService.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageService.kt
@@ -28,14 +28,16 @@ class ProjectPageService (
                 return DetailedResponse(projectPage)
         }
 
+        @Transactional
         fun createProjectPage(myId: Long, request: CreateRequest): DetailedResponse {
                 val project = projectRepository.findUndeletedProjectById(request.projectId)
                         ?: throw ProjectNotFoundException(request.projectId)
                 if (!project.isAccessibleTo(myId)) throw NonAccessibleProjectException(request.projectId)
-                val projectPage = ProjectPage(project, request)
+                val projectPage = projectPageRepository.save(ProjectPage(project, request))
                 return DetailedResponse(projectPage)
         }
 
+        @Transactional
         fun patchProjectPage(myId: Long, id:Long, request: PatchRequest)
         : DetailedResponse{
                 val projectPage = projectPageRepository.findUndeletedProjectPageById(id)
@@ -45,6 +47,7 @@ class ProjectPageService (
                 return DetailedResponse(projectPage)
         }
 
+        @Transactional
         fun deleteProjectPage(myId: Long, id:Long)
         : SimpleResponse {
                 val projectPage = projectPageRepository.findUndeletedProjectPageById(id)

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageService.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageService.kt
@@ -1,9 +1,6 @@
 package com.wafflestudio.webgam.domain.page.service
 
-import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.SimpleResponse
-import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.DetailedResponse
-import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.CreateRequest
-import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.PatchRequest
+import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.*
 import com.wafflestudio.webgam.domain.page.exception.NonAccessibleProjectPageException
 import com.wafflestudio.webgam.domain.page.exception.ProjectPageNotFoundException
 import com.wafflestudio.webgam.domain.page.model.ProjectPage
@@ -11,7 +8,6 @@ import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
 import com.wafflestudio.webgam.domain.project.exception.NonAccessibleProjectException
 import com.wafflestudio.webgam.domain.project.exception.ProjectNotFoundException
 import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
-import com.wafflestudio.webgam.global.common.dto.ListResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -49,12 +45,11 @@ class ProjectPageService (
 
         @Transactional
         fun deleteProjectPage(myId: Long, id:Long)
-        : SimpleResponse {
+        {
                 val projectPage = projectPageRepository.findUndeletedProjectPageById(id)
                         ?: throw ProjectPageNotFoundException(id)
                 if (!projectPage.isAccessibleTo(myId)) throw NonAccessibleProjectPageException(id)
                 projectPage.delete()
-                return SimpleResponse(projectPage)
         }
 
 

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageService.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageService.kt
@@ -17,16 +17,16 @@ class ProjectPageService (
         private val projectPageRepository: ProjectPageRepository,
         private val projectRepository: ProjectRepository
 ){
-        fun getProjectPage(myId: Long, projectId: Long): DetailedResponse {
-                val projectPage = projectPageRepository.findUndeletedProjectPageById(projectId)
-                        ?: throw ProjectPageNotFoundException(projectId)
-                if (!projectPage.isAccessibleTo(myId)) throw NonAccessibleProjectPageException(projectId)
+        fun getProjectPage(myId: Long, pageId: Long): DetailedResponse {
+                val projectPage = projectPageRepository.findUndeletedProjectPageById(pageId)
+                        ?: throw ProjectPageNotFoundException(pageId)
+                if (!projectPage.isAccessibleTo(myId)) throw NonAccessibleProjectPageException(pageId)
                 return DetailedResponse(projectPage)
         }
 
         @Transactional
         fun createProjectPage(myId: Long, request: CreateRequest): DetailedResponse {
-                val project = projectRepository.findUndeletedProjectById(request.projectId)
+                val project = projectRepository.findUndeletedProjectById(request.projectId!!)
                         ?: throw ProjectNotFoundException(request.projectId)
                 if (!project.isAccessibleTo(myId)) throw NonAccessibleProjectException(request.projectId)
                 val projectPage = projectPageRepository.save(ProjectPage(project, request))

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectController.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectController.kt
@@ -1,18 +1,15 @@
 package com.wafflestudio.webgam.domain.project.controller
 
+import com.wafflestudio.webgam.domain.project.dto.ProjectDto.*
 import com.wafflestudio.webgam.domain.project.service.ProjectService
-import com.wafflestudio.webgam.domain.project.dto.ProjectDto.SimpleResponse
-import com.wafflestudio.webgam.domain.project.dto.ProjectDto.DetailedResponse
-import com.wafflestudio.webgam.domain.project.dto.ProjectDto.CreateRequest
-import com.wafflestudio.webgam.domain.project.dto.ProjectDto.PatchRequest
 import com.wafflestudio.webgam.global.common.dto.ListResponse
+import com.wafflestudio.webgam.global.security.CurrentUser
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
+import org.springframework.data.domain.Slice
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import com.wafflestudio.webgam.global.common.dto.PageResponse
-import com.wafflestudio.webgam.global.security.CurrentUser
-import jakarta.validation.Valid
 
 @Validated
 @RestController
@@ -29,7 +26,7 @@ class ProjectController(
     fun getProjects(
             @RequestParam(required = false, defaultValue = "0") page: Int,
             @RequestParam(required = false, defaultValue = "10") size: Int,
-    ): ResponseEntity<PageResponse<SimpleResponse>> {
+    ): ResponseEntity<Slice<SimpleResponse>> {
         val projectList = projectService.getProjectList(page, size)
         return ResponseEntity.ok(projectList)
     }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectController.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*
 
 @Validated
 @RestController
-@RequestMapping("/api/v1/project")
+@RequestMapping("/api/v1/projects")
 class ProjectController(
         private val projectService: ProjectService,
 ) {

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectController.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectController.kt
@@ -56,7 +56,7 @@ class ProjectController(
     @DeleteMapping("/{id}")
     fun deleteProject(@CurrentUser myId: Long, @PathVariable("id") @Positive id: Long)
     : ResponseEntity<DetailedResponse> {
-        val project = projectService.deleteProject(myId, id)
-        return ResponseEntity.ok(project)
+        projectService.deleteProject(myId, id)
+        return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectController.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectController.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.webgam.global.common.dto.ListResponse
 import com.wafflestudio.webgam.global.security.CurrentUser
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
 import org.springframework.data.domain.Slice
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -24,8 +25,8 @@ class ProjectController(
 
     @GetMapping("")
     fun getProjects(
-            @RequestParam(required = false, defaultValue = "0") page: Int,
-            @RequestParam(required = false, defaultValue = "10") size: Int,
+            @RequestParam(required = false, defaultValue = "0") @PositiveOrZero page: Int,
+            @RequestParam(required = false, defaultValue = "10") @Positive size: Int,
     ): ResponseEntity<Slice<SimpleResponse>> {
         val projectList = projectService.getProjectList(page, size)
         return ResponseEntity.ok(projectList)

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/model/Project.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/model/Project.kt
@@ -37,4 +37,9 @@ class Project(
         owner.projects.add(this)
     }
 
+    override fun delete() {
+        isDeleted = true
+        pages.forEach { it.delete() }
+    }
+
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryCustom.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryCustom.kt
@@ -1,8 +1,11 @@
 package com.wafflestudio.webgam.domain.project.repository
 
 import com.wafflestudio.webgam.domain.project.model.Project
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface ProjectRepositoryCustom {
     fun findUndeletedProjectById(id: Long): Project?
-    fun findAllByOwnerIdEquals(ownerId: Long): List<Project>
+    fun findUndeletedAllByOwnerIdEquals(ownerId: Long): List<Project>
+    fun findUndeletedAll(pageable: Pageable): Slice<Project>
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryImpl.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryImpl.kt
@@ -5,6 +5,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.webgam.domain.project.model.Project
 import com.wafflestudio.webgam.domain.project.model.QProject.project
 import com.wafflestudio.webgam.domain.user.model.QUser.user
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -14,20 +17,37 @@ class ProjectRepositoryImpl(
 
     fun id(id: Long): BooleanExpression = project.id.eq(id)
     fun undeletedProject(): BooleanExpression = project.isDeleted.isFalse
-    fun undeletedUser(): BooleanExpression = user.isDeleted.isFalse
 
     override fun findUndeletedProjectById(id: Long): Project? = jpaQueryFactory
         .select(project)
         .from(project)
         .leftJoin(project.owner, user).fetchJoin()
-        .where(id(id), undeletedProject(), undeletedUser())
+        .where(id(id), undeletedProject())
         .fetchOne()
 
-    override fun findAllByOwnerIdEquals(ownerId: Long): List<Project> = jpaQueryFactory
+    override fun findUndeletedAllByOwnerIdEquals(ownerId: Long): List<Project> = jpaQueryFactory
             .select(project)
             .from(project)
             .leftJoin(project.owner, user).fetchJoin()
-            .where(user.id.eq(ownerId), undeletedProject(), undeletedUser())
+            .where(user.id.eq(ownerId), undeletedProject())
             .fetch()
 
+    override fun findUndeletedAll(pageable: Pageable): Slice<Project> {
+        val projects = jpaQueryFactory
+            .select(project)
+            .from(project)
+            .leftJoin(project.owner, user).fetchJoin()
+            .where(undeletedProject())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        var hasNext = false
+        if (projects.size > pageable.pageSize) {
+            projects.removeAt(pageable.pageSize)
+            hasNext = true
+        }
+
+        return SliceImpl(projects, pageable, hasNext)
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/service/ProjectService.kt
@@ -13,6 +13,7 @@ import com.wafflestudio.webgam.domain.user.repository.UserRepository
 import com.wafflestudio.webgam.domain.user.service.UserService
 import com.wafflestudio.webgam.global.common.dto.ListResponse
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -31,14 +32,13 @@ class ProjectService (
         return DetailedResponse(project)
     }
 
-    fun getProjectList(page: Int, size:Int): PageResponse<SimpleResponse> {
+    fun getProjectList(page: Int, size:Int): Slice<SimpleResponse> {
         val pageRequest = PageRequest.of(page, size)
-        val projects = projectRepository.findAll(pageRequest)
-        return PageResponse(projects.content.map{SimpleResponse(it)}, page, size, projects.numberOfElements)
+        return projectRepository.findUndeletedAll(pageRequest).map { SimpleResponse(it) }
     }
 
     fun getUserProject(userId: Long): ListResponse<SimpleResponse> {
-        val projects = projectRepository.findAllByOwnerIdEquals(userId)
+        val projects = projectRepository.findUndeletedAllByOwnerIdEquals(userId)
         return ListResponse(projects.map{ SimpleResponse(it) })
     }
 

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/project/service/ProjectService.kt
@@ -1,16 +1,11 @@
 package com.wafflestudio.webgam.domain.project.service
 
-import com.wafflestudio.webgam.domain.project.dto.ProjectDto.CreateRequest
-import com.wafflestudio.webgam.domain.project.dto.ProjectDto.PatchRequest
-import com.wafflestudio.webgam.domain.project.dto.ProjectDto.DetailedResponse
-import com.wafflestudio.webgam.domain.project.dto.ProjectDto.SimpleResponse
+import com.wafflestudio.webgam.domain.project.dto.ProjectDto.*
 import com.wafflestudio.webgam.domain.project.exception.NonAccessibleProjectException
-import com.wafflestudio.webgam.global.common.dto.PageResponse
 import com.wafflestudio.webgam.domain.project.exception.ProjectNotFoundException
 import com.wafflestudio.webgam.domain.project.model.Project
 import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
 import com.wafflestudio.webgam.domain.user.repository.UserRepository
-import com.wafflestudio.webgam.domain.user.service.UserService
 import com.wafflestudio.webgam.global.common.dto.ListResponse
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
@@ -22,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class ProjectService (
         private val projectRepository: ProjectRepository,
-        private val userService: UserService,
         private val userRepository: UserRepository
 ){
 
@@ -59,10 +53,9 @@ class ProjectService (
     }
 
     @Transactional
-    fun deleteProject(myId: Long, projectId: Long): DetailedResponse {
+    fun deleteProject(myId: Long, projectId: Long) {
         val project = projectRepository.findUndeletedProjectById(projectId) ?: throw ProjectNotFoundException(projectId)
         if (!project.isAccessibleTo(myId)) throw NonAccessibleProjectException(projectId)
         project.delete()
-        return DetailedResponse(project)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/domain/user/model/User.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/domain/user/model/User.kt
@@ -35,4 +35,9 @@ class User(
     override fun isAccessibleTo(currentUserId: Long): Boolean {
         return (this.id == currentUserId)
     }
+
+    override fun delete() {
+        isDeleted = true
+        projects.forEach { it.delete() }
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/dto/ErrorResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/dto/ErrorResponse.kt
@@ -1,4 +1,6 @@
-package com.wafflestudio.webgam.global.common.exception
+package com.wafflestudio.webgam.global.common.dto
+
+import com.wafflestudio.webgam.global.common.exception.WebgamException
 
 data class ErrorResponse(
         val errorCode: Int,

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/dto/PageResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/dto/PageResponse.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.webgam.global.common.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.springframework.data.domain.Page
 
 data class PageResponse<T> (
         val content: List<T>,

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/Error.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/Error.kt
@@ -1,5 +1,0 @@
-package com.wafflestudio.webgam.global.common.exception
-
-interface Error {
-    fun code(): Int
-}

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/ErrorType.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/ErrorType.kt
@@ -2,7 +2,10 @@ package com.wafflestudio.webgam.global.common.exception
 
 enum class ErrorType {
     ;
-    enum class BadRequest(private val code: Int): Error {
+    interface ErrorTypeInterface {
+        fun code(): Int
+    }
+    enum class BadRequest(private val code: Int): ErrorTypeInterface {
         DEFAULT(0),
         INVALID_FIELD(1),
         NO_REFRESH_TOKEN(2),
@@ -17,7 +20,7 @@ enum class ErrorType {
         }
     }
 
-    enum class Unauthorized(private val code: Int): Error {
+    enum class Unauthorized(private val code: Int): ErrorTypeInterface {
         DEFAULT(1000),
         LOGIN_FAIL(1001),
         INVALID_JWT(1002),
@@ -28,7 +31,7 @@ enum class ErrorType {
         }
     }
 
-    enum class Forbidden(private val code: Int): Error {
+    enum class Forbidden(private val code: Int): ErrorTypeInterface {
         DEFAULT(3000),
         NO_ACCESS(3001),
         NON_ACCESSIBLE_PROJECT(3100),
@@ -42,7 +45,7 @@ enum class ErrorType {
         }
     }
 
-    enum class NotFound(private val code: Int): Error {
+    enum class NotFound(private val code: Int): ErrorTypeInterface {
         DEFAULT(4000),
         USER_NOT_FOUND(4001),
         PROJECT_NOT_FOUND(4100),
@@ -56,7 +59,7 @@ enum class ErrorType {
         }
     }
 
-    enum class Conflict(private val code: Int): Error {
+    enum class Conflict(private val code: Int): ErrorTypeInterface {
         DEFAULT(9000),
         DUPLICATE_USER_IDENTIFIER(9001),
         ONLY_SINGLE_EVENT_PER_OBJECT(9400),
@@ -67,7 +70,7 @@ enum class ErrorType {
         }
     }
 
-    enum class ServerError(private val code: Int): Error {
+    enum class ServerError(private val code: Int): ErrorTypeInterface {
         DEFAULT(10000),
         ;
 

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/ErrorType.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/ErrorType.kt
@@ -8,6 +8,8 @@ enum class ErrorType {
         NO_REFRESH_TOKEN(2),
         CONSTRAINT_VIOLATION(3),
         JSON_PARSE_ERROR(4),
+        PARAMETER_TYPE_MISMATCH(5),
+        PAGE_IN_OTHER_PROJECT(400),
         ;
 
         override fun code(): Int {

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamControllerAdvice.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamControllerAdvice.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.webgam.global.common.exception
 
+import com.wafflestudio.webgam.global.common.dto.ErrorResponse
 import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.JSON_PARSE_ERROR
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.PARAMETER_TYPE_MISMATCH
 import jakarta.validation.ConstraintViolationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -10,6 +12,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @RestControllerAdvice
 class WebgamControllerAdvice {
@@ -49,6 +52,12 @@ class WebgamControllerAdvice {
             HttpStatus.BAD_REQUEST)
     }
 
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun parameterTypeMismatch(e: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity(
+            ErrorResponse(PARAMETER_TYPE_MISMATCH.code(), "Parameter type mismatch", "Check your request URL"),
+            HttpStatus.BAD_REQUEST)
+    }
 
     @ExceptionHandler(WebgamException.Unauthorized::class)
     fun unauthorized(webgamException: WebgamException): ResponseEntity<ErrorResponse> {

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamException.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/exception/WebgamException.kt
@@ -1,7 +1,9 @@
 package com.wafflestudio.webgam.global.common.exception
 
+import com.wafflestudio.webgam.global.common.exception.ErrorType.ErrorTypeInterface
+
 sealed class WebgamException(
-    val errorType: Error,
+    val errorType: ErrorTypeInterface,
     val detail: String
 ): RuntimeException() {
     abstract class BadRequest(errorType: ErrorType.BadRequest, detail: String): WebgamException(errorType, detail)

--- a/src/main/kotlin/com/wafflestudio/webgam/global/common/model/BaseTimeTraceLazyDeletedEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/common/model/BaseTimeTraceLazyDeletedEntity.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
-open class BaseTimeTraceLazyDeletedEntity (
+abstract class BaseTimeTraceLazyDeletedEntity (
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     open val id: Long = 0,
 
@@ -28,7 +28,5 @@ open class BaseTimeTraceLazyDeletedEntity (
 
     open var isDeleted: Boolean = false,
 ) {
-    open fun delete() { // FIXME: open -> abstract
-        isDeleted = true
-    }
+    abstract fun delete()
 }

--- a/src/main/kotlin/com/wafflestudio/webgam/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/config/SecurityConfig.kt
@@ -36,7 +36,7 @@ class SecurityConfig(
             "http://webgam-dev.s3-website.ap-northeast-2.amazonaws.com:3000",
             "http://localhost:3000",
         )
-        private val GET_WHITELIST: Array<String> = arrayOf("/ping", "/api/v1/project")
+        private val GET_WHITELIST: Array<String> = arrayOf("/ping", "/api/v1/projects")
         private val POST_WHITELIST: Array<String> = arrayOf("/signup", "/login/**", "/logout", "/refresh")
     }
 

--- a/src/main/kotlin/com/wafflestudio/webgam/global/security/controller/WebgamAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/security/controller/WebgamAccessDeniedHandler.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.webgam.global.security.controller
 
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.GsonBuilder
-import com.wafflestudio.webgam.global.common.exception.ErrorResponse
+import com.wafflestudio.webgam.global.common.dto.ErrorResponse
 import com.wafflestudio.webgam.global.common.exception.WebgamException
 import com.wafflestudio.webgam.global.security.exception.NoAccessException
 import jakarta.servlet.http.HttpServletRequest

--- a/src/main/kotlin/com/wafflestudio/webgam/global/security/controller/WebgamAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/wafflestudio/webgam/global/security/controller/WebgamAuthenticationEntryPoint.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.webgam.global.security.controller
 
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.GsonBuilder
-import com.wafflestudio.webgam.global.common.exception.ErrorResponse
+import com.wafflestudio.webgam.global.common.dto.ErrorResponse
 import com.wafflestudio.webgam.global.common.exception.WebgamException
 import com.wafflestudio.webgam.global.security.exception.UnauthorizedException
 import jakarta.servlet.http.HttpServletRequest

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,14 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/webgam_db
+    username: webgam_admin
+    password: WEBGAM_admin_01
+
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: create

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,10 +7,9 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: 500
-    database-platform: org.hibernate.dialect.MySQLDialect
     generate-ddl: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
 
   jackson:
     property-naming-strategy: SNAKE_CASE
@@ -21,53 +20,6 @@ jwt:
 webgam:
   admin-password: ~
   dev-password: ~
-
----
-
-spring:
-  config:
-    activate:
-      on-profile: local
-
-  datasource:
-    url: jdbc:mysql://localhost:3306/webgam_db
-    username: webgam_admin
-    password: WEBGAM_admin_01
-
-  jpa:
-    generate-ddl: true
-    hibernate:
-      ddl-auto: create
-
----
-
-spring:
-  config:
-    activate:
-      on-profile: test
-
-  datasource:
-    url: jdbc:mysql://localhost:3306/webgam_db_test
-    username: webgam_admin
-    password: WEBGAM_admin_01
-
-  jpa:
-    generate-ddl: true
-    hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        format_sql: true
-        use_sql_comments: true
-        highlight_sql: true
-        generate_statistics: true
-
-logging:
-  level:
-    org.springframework.security: TRACE
-    org.hibernate.orm.jdbc.bind: TRACE
-    org.hibernate.sql: DEBUG
-    org.hibernate.stat: DEBUG
 
 ---
 

--- a/src/test/kotlin/com/wafflestudio/webgam/Relation.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/Relation.kt
@@ -1,0 +1,98 @@
+package com.wafflestudio.webgam
+
+import com.wafflestudio.webgam.domain.event.dto.ObjectEventDto
+import com.wafflestudio.webgam.domain.event.model.ObjectEvent
+import com.wafflestudio.webgam.domain.event.model.TransitionType
+import com.wafflestudio.webgam.domain.`object`.dto.PageObjectDto
+import com.wafflestudio.webgam.domain.`object`.model.PageObject
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.DEFAULT
+import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto
+import com.wafflestudio.webgam.domain.page.model.ProjectPage
+import com.wafflestudio.webgam.domain.project.dto.ProjectDto
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.user.model.User
+
+object Relation {
+    infix fun withUser(name: String) = UserConfiguration(User("$name-id", name, "$name@email.com", ""))
+    interface Configuration {
+        fun build(): User
+    }
+    class UserConfiguration(private val user: User): Configuration {
+        override fun build() = user
+        infix fun deleted(boolean: Boolean): UserConfiguration {
+            if (boolean) user.delete()
+            return this
+        }
+        infix fun withProject(name: String) = ProjectConfiguration(user, name, this)
+    }
+
+    class ProjectConfiguration(private val project: Project, private val chain: UserConfiguration): Configuration {
+        constructor(user: User, name: String, chain: UserConfiguration): this(
+            project = Project(user, ProjectDto.CreateRequest(name)),
+            chain = chain
+        )
+        override fun build() = chain.build()
+        infix fun deleted(boolean: Boolean): ProjectConfiguration {
+            if (boolean) project.delete()
+            return this
+        }
+        infix fun withProject(name: String) = chain.withProject(name)
+        infix fun withPage(name: String) = PageConfiguration(project, name, this)
+    }
+
+    class PageConfiguration(private val page: ProjectPage, private val chain: ProjectConfiguration): Configuration {
+        constructor(project: Project, name: String, chain: ProjectConfiguration): this(
+            page = ProjectPage(project, ProjectPageDto.CreateRequest(0L, name)),
+            chain = chain
+        )
+        override fun build() = chain.build()
+        infix fun deleted(boolean: Boolean): PageConfiguration {
+            if (boolean) page.delete()
+            return this
+        }
+        infix fun withProject(name: String) = chain.withProject(name)
+        infix fun withPage(name: String) = chain.withPage(name)
+        infix fun withObject(name: String) = ObjectConfiguration(page, name, this)
+    }
+
+    class ObjectConfiguration(private val obj: PageObject, private val chain: PageConfiguration): Configuration {
+        constructor(page: ProjectPage, name: String, chain: PageConfiguration) : this(
+            obj = PageObject(page, PageObjectDto.CreateRequest(0L, name, DEFAULT, 0, 0, 0, 0, 0, null, null, null)),
+            chain = chain
+        )
+        override fun build() = chain.build()
+        infix fun deleted(boolean: Boolean): ObjectConfiguration {
+            if (boolean) obj.delete()
+            return this
+        }
+        infix fun type(type: PageObjectType): ObjectConfiguration {
+            obj.type = type
+            return this
+        }
+        infix fun withProject(name: String) = chain.withProject(name)
+        infix fun withPage(name: String) = chain.withPage(name)
+        infix fun withObject(name: String) = chain.withObject(name)
+        infix fun withEvent(type: TransitionType) = EventConfiguration(obj, type, this)
+    }
+
+    class EventConfiguration(private val event: ObjectEvent, private val chain: ObjectConfiguration): Configuration {
+        constructor(obj: PageObject, type: TransitionType, chain: ObjectConfiguration): this(
+            event = ObjectEvent(ObjectEventDto.CreateRequest(0L, type, 0L), obj),
+            chain = chain
+        )
+        override fun build() = chain.build()
+        infix fun deleted(boolean: Boolean): EventConfiguration {
+            if (boolean) event.delete()
+            return this
+        }
+        infix fun withNextPage(name: String): EventConfiguration {
+            event.nextPage = event.`object`.page.project.pages.first { it.name == name }
+            return this
+        }
+        infix fun withProject(name: String) = chain.withProject(name)
+        infix fun withPage(name: String) = chain.withPage(name)
+        infix fun withObject(name: String) = chain.withObject(name)
+        infix fun withEvent(type: TransitionType) = chain.withEvent(type)
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/TestUtils.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/TestUtils.kt
@@ -1,5 +1,9 @@
 package com.wafflestudio.webgam
 
+import com.wafflestudio.webgam.domain.event.model.TransitionType
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.*
+import com.wafflestudio.webgam.global.common.exception.ErrorType
+
 class TestUtils {
     companion object {
         fun makeFieldList(vararg fields: List<Pair<Any?, Int?>>): List<Pair<List<Any?>, Pair<Int, Int?>>> {
@@ -18,5 +22,41 @@ class TestUtils {
 
             return main
         }
+
+        fun pathVariableIds() = listOf(
+            listOf("1", "3", "5", "100").map { it to null },
+            listOf("0", "-1", "-100").map { it to ErrorType.BadRequest.CONSTRAINT_VIOLATION.code() }).flatten()
+
+        fun testData1() = listOf(
+            Relation withUser "user-01"
+                        withProject "project-01"
+                            withPage "page-01"
+                            withPage "page-02"
+                                withObject "object-01" type DEFAULT
+                                withObject "object-02" type DEFAULT
+                                    withEvent TransitionType.DEFAULT deleted true
+                                withObject "object-03" type IMAGE
+                                    withEvent TransitionType.DEFAULT deleted true
+                                    withEvent TransitionType.DEFAULT
+                                withObject "object-04" type TEXT
+                                    withEvent TransitionType.DEFAULT deleted true
+                                    withEvent TransitionType.DEFAULT deleted true
+                                    withEvent TransitionType.DEFAULT withNextPage "page-01"
+
+                        withProject "project-02" deleted true
+                            withPage "page-03" deleted true
+                            withPage "page-04" deleted true
+                                withObject "object-05" type IMAGE deleted true
+                                withObject "object-06" type DEFAULT deleted true
+                                    withEvent TransitionType.DEFAULT withNextPage "page-03" deleted true
+                                withObject "object-07" type IMAGE deleted true
+                                withObject "object-08" type TEXT deleted true
+            ,
+            Relation withUser "user-02" deleted true
+                        withProject "project-03" deleted true
+            ,
+            Relation withUser "user-03"
+                        withProject "project-04"
+        ).map { it.build() }
     }
 }

--- a/src/test/kotlin/com/wafflestudio/webgam/TestUtils.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/TestUtils.kt
@@ -58,5 +58,14 @@ class TestUtils {
             Relation withUser "user-03"
                         withProject "project-04"
         ).map { it.build() }
+
+        fun docTestData() = listOf(
+            Relation withUser "user-01"
+                        withProject "project-01"
+                            withPage "page-01"
+                                withObject "object-01" type DEFAULT
+                                    withEvent TransitionType.DEFAULT withNextPage "page-01"
+                                withObject "object-02" type TEXT
+        ).map { it.build() }
     }
 }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/event/repository/ObjectEventRepositoryImplTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/event/repository/ObjectEventRepositoryImplTest.kt
@@ -1,87 +1,58 @@
 package com.wafflestudio.webgam.domain.event.repository
 
-import com.wafflestudio.webgam.domain.event.model.ObjectEvent
-import com.wafflestudio.webgam.domain.event.model.TransitionType
-import com.wafflestudio.webgam.domain.`object`.model.PageObject
-import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.DEFAULT
-import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
-import com.wafflestudio.webgam.domain.page.model.ProjectPage
-import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
-import com.wafflestudio.webgam.domain.project.model.Project
-import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
-import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.TestUtils.Companion.testData1
 import com.wafflestudio.webgam.domain.user.repository.UserRepository
 import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.Spec
-import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Tag
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 
 @DataJpaTest
 @Import(TestQueryDslConfig::class)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
-@Tag("Repository-Test")
-@DisplayName("ObjectEventRepository Data JPA 테스트")
+@DisplayName("ObjectEventRepository 테스트")
 class ObjectEventRepositoryImplTest(
-    @Autowired private val userRepository: UserRepository,
-    @Autowired private val projectRepository: ProjectRepository,
-    @Autowired private val projectPageRepository: ProjectPageRepository,
-    @Autowired private val pageObjectRepository: PageObjectRepository,
-    @Autowired private val objectEventRepository: ObjectEventRepository,
-): DescribeSpec() {
+    private val userRepository: UserRepository,
+    private val objectEventRepository: ObjectEventRepository,
+): BehaviorSpec() {
 
-    private val user = userRepository.save(User("test-id", "test-username", "test@email.com", ""))
-    private val project = projectRepository.save(Project(user, "test-project"))
-    private val page = projectPageRepository.save(ProjectPage(project, "test-page"))
-    private val pageObject = pageObjectRepository.save(PageObject(page, "test-object", DEFAULT, 0, 0, 0, 0, 0, null, null, null, null))
-    private val event = objectEventRepository.save(ObjectEvent(pageObject, null, TransitionType.DEFAULT))
-    private val deletedEvent = objectEventRepository.save(ObjectEvent(pageObject, null, TransitionType.DEFAULT))
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
 
-    override suspend fun beforeSpec(spec: Spec) {
+    override suspend fun afterSpec(spec: Spec) {
         withContext(Dispatchers.IO) {
-            deletedEvent.delete()
-            objectEventRepository.save(deletedEvent)
+            userRepository.deleteAll()
         }
     }
 
     init {
-        this.describe("findUndeletedObjectEventById 호출될 때") {
-            context("성공적인 경우") {
-                val id = event.id
-                val foundEvent = objectEventRepository.findUndeletedObjectEventById(id)
+        this.Given("testData1") {
+            val data = testData1()
+            userRepository.saveAll(data)
 
-                it ("삭제 되지 않은 ObjectEvent가 반환된다") {
-                    foundEvent shouldNotBe null
-                    foundEvent!!.isDeleted shouldBe false
+            val events = data.map { u -> u.projects.map { p -> p.pages.map { pp -> pp.objects.map { it.events }
+                .flatten() }.flatten() }.flatten() }.flatten()
+            val maxId = objectEventRepository.findAll().maxOf { it.id }
+
+            When("findUndeletedObjectEventById 호출하면") {
+                for (event in events) {
+                    val foundEvent = objectEventRepository.findUndeletedObjectEventById(event.id)
+                    if (!event.isDeleted) {
+                        Then("삭제되지 않은 이벤트 객체를 반환한다: ${event.id}") { foundEvent shouldBe event }
+                    } else {
+                        Then("삭제 되었으면 NULL을 반환한다: ${event.id}") { foundEvent shouldBe null }
+                    }
                 }
-            }
 
-            context("해당 id를 갖는 PageObject가 없는 경우") {
-                val id = deletedEvent.id + 1000
-                val foundEvent = objectEventRepository.findUndeletedObjectEventById(id)
-
-                it ("NULL이 반환된다") {
-                    foundEvent shouldBe null
-                }
-            }
-
-            context("해당 id를 갖는 PageObject가 삭제 된 경우") {
-                val id = deletedEvent.id
-                val foundEvent = objectEventRepository.findUndeletedObjectEventById(id)
-
-                it ("NULL이 반환된다") {
-                    foundEvent shouldBe null
-                }
+                val foundEvent = objectEventRepository.findUndeletedObjectEventById(maxId + 1)
+                Then("존재하지 않은 경우에도 NULL을 반환한다") { foundEvent shouldBe null }
             }
         }
     }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/event/service/ObjectEventServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/event/service/ObjectEventServiceTest.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.webgam.domain.event.service
 
 import com.wafflestudio.webgam.domain.event.dto.ObjectEventDto.*
+import com.wafflestudio.webgam.domain.event.exception.LinkNonRelatedPageException
 import com.wafflestudio.webgam.domain.event.exception.MultipleEventAllocationException
 import com.wafflestudio.webgam.domain.event.exception.NonAccessibleObjectEventException
 import com.wafflestudio.webgam.domain.event.exception.ObjectEventNotFoundException
@@ -10,29 +11,22 @@ import com.wafflestudio.webgam.domain.event.repository.ObjectEventRepository
 import com.wafflestudio.webgam.domain.`object`.exception.NonAccessiblePageObjectException
 import com.wafflestudio.webgam.domain.`object`.exception.PageObjectNotFoundException
 import com.wafflestudio.webgam.domain.`object`.model.PageObject
-import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.TEXT
 import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
 import com.wafflestudio.webgam.domain.page.exception.NonAccessibleProjectPageException
 import com.wafflestudio.webgam.domain.page.exception.ProjectPageNotFoundException
 import com.wafflestudio.webgam.domain.page.model.ProjectPage
 import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.project.model.Project
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.core.test.TestCase
-import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.shouldBe
-import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import org.junit.jupiter.api.Tag
+import java.time.LocalDateTime
 
-@Tag("Unit-Test")
 @DisplayName("ObjectEventService 단위 테스트")
 class ObjectEventServiceTest: DescribeSpec() {
 
@@ -41,180 +35,206 @@ class ObjectEventServiceTest: DescribeSpec() {
         private val pageObjectRepository = mockk<PageObjectRepository>()
         private val objectEventRepository = mockk<ObjectEventRepository>()
         private val objectEventService = ObjectEventService(projectPageRepository, pageObjectRepository, objectEventRepository)
+        private val project = mockk<Project>()
+        private val otherProject = mockk<Project>()
         private val page = mockk<ProjectPage>()
         private val nonAccessiblePage = mockk<ProjectPage>()
-        private val pageObject = PageObject(page, "test-object", TEXT, 0, 0, 0, 0, 0, "", 0, "", null)
+        private val pageInOtherProject = mockk<ProjectPage>()
+        private val pageObject = mockk<PageObject>()
         private val nonAccessibleObject = mockk<PageObject>()
         private val objectWithEvent = mockk<PageObject>()
         private val event = ObjectEvent(pageObject, null, DEFAULT)
         private val nonAccessibleEvent = mockk<ObjectEvent>()
         private val dummyEvent = mockk<ObjectEvent>()
-        private val triggeredEvents = mutableListOf<ObjectEvent>()
-        private val createdEventSlot = CapturingSlot<ObjectEvent>()
 
         private const val USER_ID = 1L
-        private const val OBJ_ID = 1L
-        private const val NON_ACC_OBJ_ID = 2L
-        private const val NON_EXI_OBJ_ID = 3L
-        private const val EVENT_EXI_OBJ_ID = 4L
-        private const val PAGE_ID = 1L
-        private const val NON_ACC_PAGE_ID = 2L
-        private const val NON_EXI_PAGE_ID = 3L
-        private const val EVENT_ID = 1L
-        private const val NON_ACC_EVENT_ID = 2L
-        private const val NON_EXI_EVENT_ID = 3L
+        private const val NORMAL = 1L
+        private const val DELETED = 2L
+        private const val NON_ACCESSIBLE = 3L
+        private const val PRE_ALLOCATED = 4L
+        private const val OTHER = 4L
     }
 
     override suspend fun beforeSpec(spec: Spec) {
-        every { projectPageRepository.findUndeletedProjectPageById(PAGE_ID) } returns page
-        every { projectPageRepository.findUndeletedProjectPageById(NON_ACC_PAGE_ID) } returns nonAccessiblePage
-        every { projectPageRepository.findUndeletedProjectPageById(NON_EXI_PAGE_ID) } returns null
+        every { projectPageRepository.findUndeletedProjectPageById(NORMAL) } returns page
+        every { projectPageRepository.findUndeletedProjectPageById(DELETED) } returns null
+        every { projectPageRepository.findUndeletedProjectPageById(NON_ACCESSIBLE) } returns nonAccessiblePage
+        every { projectPageRepository.findUndeletedProjectPageById(OTHER) } returns pageInOtherProject
 
-        every { pageObjectRepository.findUndeletedPageObjectById(OBJ_ID) } returns pageObject
-        every { pageObjectRepository.findUndeletedPageObjectById(NON_ACC_OBJ_ID) } returns nonAccessibleObject
-        every { pageObjectRepository.findUndeletedPageObjectById(NON_EXI_OBJ_ID) } returns null
-        every { pageObjectRepository.findUndeletedPageObjectById(EVENT_EXI_OBJ_ID) } returns objectWithEvent
+        every { pageObjectRepository.findUndeletedPageObjectById(NORMAL) } returns pageObject
+        every { pageObjectRepository.findUndeletedPageObjectById(DELETED) } returns null
+        every { pageObjectRepository.findUndeletedPageObjectById(NON_ACCESSIBLE) } returns nonAccessibleObject
+        every { pageObjectRepository.findUndeletedPageObjectById(PRE_ALLOCATED) } returns objectWithEvent
 
-        every { objectEventRepository.findUndeletedObjectEventById(EVENT_ID) } returns event
-        every { objectEventRepository.findUndeletedObjectEventById(NON_ACC_EVENT_ID) } returns nonAccessibleEvent
-        every { objectEventRepository.findUndeletedObjectEventById(NON_EXI_EVENT_ID) } returns null
-
-        every { objectEventRepository.save(capture(createdEventSlot)) } answers { firstArg() }
+        every { objectEventRepository.save(any()) } returns event
+        every { objectEventRepository.findUndeletedObjectEventById(NORMAL) } returns event
+        every { objectEventRepository.findUndeletedObjectEventById(DELETED) } returns null
+        every { objectEventRepository.findUndeletedObjectEventById(NON_ACCESSIBLE) } returns nonAccessibleEvent
 
         every { nonAccessiblePage.isAccessibleTo(USER_ID) } returns false
         every { nonAccessibleObject.isAccessibleTo(USER_ID) } returns false
         every { nonAccessibleEvent.isAccessibleTo(USER_ID) } returns false
 
-        every { objectWithEvent.event } returns dummyEvent
-        every { objectWithEvent.id } returns EVENT_EXI_OBJ_ID
-
-        every { page.triggeredEvents } returns triggeredEvents
-
         every { page.isAccessibleTo(USER_ID) } returns true
-        every { objectWithEvent.isAccessibleTo(USER_ID) } returns true
-        every { event.isAccessibleTo(USER_ID) } returns true
-    }
+        every { page.triggeredEvents } returns mutableListOf()
+        every { page.project } returns project
+        every { page.id } returns NORMAL
+        every { page.name } returns "page"
+        every { page.createdAt } returns LocalDateTime.now()
+        every { page.modifiedAt } returns LocalDateTime.now()
+        every { page.createdBy } returns ""
+        every { page.modifiedBy } returns ""
 
-    override suspend fun beforeContainer(testCase: TestCase) {
-        pageObject.event?. let { pageObject.event = null }
-        page.triggeredEvents.clear()
+        every { pageInOtherProject.isAccessibleTo(USER_ID) } returns true
+        every { pageInOtherProject.project } returns otherProject
+
+        every { pageObject.isAccessibleTo(USER_ID) } returns true
+        every { pageObject.page } returns page
+        every { pageObject.event } returns null
+        every { pageObject.events } returns mutableListOf()
+
+        every { objectWithEvent.isAccessibleTo(USER_ID) } returns true
+        every { objectWithEvent.event } returns dummyEvent
     }
 
     init {
         this.describe("getEvent 호출될 때") {
             context("성공적인 경우") {
-                val response = withContext(Dispatchers.IO) { objectEventService.getEvent(USER_ID, EVENT_ID) }
                 it("ObjectEvent가 Simple Response DTO로 반환된다") {
+                    val response = shouldNotThrowAny { objectEventService.getEvent(USER_ID, NORMAL) }
                     response shouldBe SimpleResponse(event)
                 }
             }
 
             context("해당 ID를 갖는 이벤트가 존재하지 않거나 삭제됐으면") {
                 it("ObjectEventNotFoundException 예외를 던진다") {
-                    shouldThrow<ObjectEventNotFoundException> { objectEventService.getEvent(USER_ID, NON_EXI_EVENT_ID) }
+                    shouldThrow<ObjectEventNotFoundException> { objectEventService.getEvent(USER_ID, DELETED) }
                 }
             }
 
             context("해당 ID를 갖는 PageObject에 접근할 수 없으면") {
                 it("NonAccessibleObjectEventException 예외를 던진다") {
-                    shouldThrow<NonAccessibleObjectEventException> { objectEventService.getEvent(USER_ID, NON_ACC_EVENT_ID) }
+                    shouldThrow<NonAccessibleObjectEventException> { objectEventService.getEvent(USER_ID, NON_ACCESSIBLE) }
                 }
             }
         }
 
         this.describe("createEvent 호출될 때") {
             context("성공적인 경우") {
-                val responseGivenNextPageId = withContext(Dispatchers.IO) {
-                    objectEventService.createEvent(USER_ID, CreateRequest(OBJ_ID, DEFAULT, PAGE_ID))
-                }
-                val createdEvent = createdEventSlot.captured
+                val request = CreateRequest(NORMAL, DEFAULT, NORMAL)
 
                 it("생성된 ObjectEvent가 SimpleResponse DTO로 반환된다") {
-                    responseGivenNextPageId shouldBe SimpleResponse(createdEvent)
-                }
-
-                it("새로 생성된 이벤트는 연결된 오브젝트의 event로 설정된다") {
-                    pageObject.event shouldBe createdEvent
-                }
-
-                it("다음 페이지가 있으면, 페이지 triggeredEvents에 추가된다") {
-                    page.triggeredEvents shouldHaveSingleElement createdEvent
+                    val response = shouldNotThrowAny { objectEventService.createEvent(USER_ID, request) }
+                    response shouldBe SimpleResponse(event)
                 }
             }
 
             context("objectId의 오브젝트가 존재하지 않거나 삭제됐으면") {
+                val request = CreateRequest(DELETED, DEFAULT, null)
+
                 it("PageObjectNotFoundException 예외를 던진다") {
-                    shouldThrow<PageObjectNotFoundException> {
-                        objectEventService.createEvent(USER_ID, CreateRequest(NON_EXI_OBJ_ID, DEFAULT, null))
-                    }
+                    shouldThrow<PageObjectNotFoundException> { objectEventService.createEvent(USER_ID, request) }
                 }
             }
 
             context("objectId의 오브젝트에 접근할 수 없으면") {
+                val request = CreateRequest(NON_ACCESSIBLE, DEFAULT, null)
+
                 it("NonAccessiblePageObjectException 예외를 던진다") {
-                    shouldThrow<NonAccessiblePageObjectException> {
-                        objectEventService.createEvent(USER_ID, CreateRequest(NON_ACC_OBJ_ID, DEFAULT, null))
-                    }
+                    shouldThrow<NonAccessiblePageObjectException> { objectEventService.createEvent(USER_ID, request) }
                 }
             }
 
             context("objectId의 오브젝트에 이미 이벤트가 설정되어 있으면") {
+                val request = CreateRequest(PRE_ALLOCATED, DEFAULT, null)
+
                 it("MultipleEventAllocationException 예외를 던진다") {
-                    shouldThrow<MultipleEventAllocationException> {
-                        objectEventService.createEvent(USER_ID, CreateRequest(EVENT_EXI_OBJ_ID, DEFAULT, null))
-                    }
+                    shouldThrow<MultipleEventAllocationException> { objectEventService.createEvent(USER_ID, request) }
                 }
             }
 
             context("nextPageId의 페이지가 존재하지 않거나 삭제됐으면") {
+                val request = CreateRequest(NORMAL, DEFAULT, DELETED)
+
                 it("ProjectPageNotFoundException 예외를 던진다") {
                     shouldThrow<ProjectPageNotFoundException> {
-                        objectEventService.createEvent(USER_ID, CreateRequest(OBJ_ID, DEFAULT, NON_EXI_PAGE_ID))
+                        objectEventService.createEvent(USER_ID, request)
                     }
                 }
             }
 
             context("nextPageId의 페이지에 접근할 수 없으면") {
+                val request = CreateRequest(NORMAL, DEFAULT, NON_ACCESSIBLE)
+
                 it("NonAccessibleProjectPageException 예외를 던진다") {
-                    shouldThrow<NonAccessibleProjectPageException> {
-                        objectEventService.createEvent(USER_ID, CreateRequest(OBJ_ID, DEFAULT, NON_ACC_PAGE_ID))
-                    }
+                    shouldThrow<NonAccessibleProjectPageException> { objectEventService.createEvent(USER_ID, request) }
+                }
+            }
+
+            context("nextPageId의 페이지가 다른 프로젝트에 있는 경우") {
+                val request = CreateRequest(NORMAL, DEFAULT, OTHER)
+
+                it("LinkNonRelatedPageException 예외를 던진다") {
+                    shouldThrow<LinkNonRelatedPageException> { objectEventService.createEvent(USER_ID, request) }
                 }
             }
         }
 
         this.describe("updateEvent 호출될 때") {
-            context("성공적인 경우: transitionType이 NULL이 아닐 때") {
-                val response = withContext(Dispatchers.IO) {
-                    objectEventService.updateEvent(USER_ID, EVENT_ID, PatchRequest(null, PAGE_ID))
-                }
+            context("성공적인 경우") {
+                val request = PatchRequest(null, NORMAL)
 
                 it("수정된 ObjectEvent가 Simple Response DTO로 반환된다") {
+                    val response = shouldNotThrowAny { objectEventService.updateEvent(USER_ID, NORMAL, request) }
                     response shouldBe SimpleResponse(event)
-                }
-
-                it("페이지 triggeredEvents에 추가된다") {
-                    page.triggeredEvents shouldContain event
-                }
-
-                it("request의 NULL인 필드는 수정되지 않는다") {
-                    event.transitionType shouldBe DEFAULT
                 }
             }
 
             context("해당 ID를 갖는 이벤트가 존재하지 않거나 삭제됐으면") {
+                val request = PatchRequest(null, NORMAL)
+
                 it("ObjectEventNotFoundException 예외를 던진다") {
                     shouldThrow<ObjectEventNotFoundException> {
-                        objectEventService.updateEvent(USER_ID, NON_EXI_EVENT_ID, PatchRequest(null, null))
+                        objectEventService.updateEvent(USER_ID, DELETED, request)
                     }
                 }
             }
 
             context("해당 ID를 갖는 PageObject에 접근할 수 없으면") {
+                val request = PatchRequest(null, NORMAL)
+
                 it("NonAccessibleObjectEventException 예외를 던진다") {
                     shouldThrow<NonAccessibleObjectEventException> {
-                        objectEventService.updateEvent(USER_ID, NON_ACC_EVENT_ID, PatchRequest(null, null))
+                        objectEventService.updateEvent(USER_ID, NON_ACCESSIBLE, request)
                     }
+                }
+            }
+
+            context("nextPageId의 페이지가 존재하지 않거나 삭제됐으면") {
+                val request = PatchRequest(null, DELETED)
+
+                it("ProjectPageNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectPageNotFoundException> {
+                        objectEventService.updateEvent(USER_ID, NORMAL, request)
+                    }
+                }
+            }
+
+            context("nextPageId의 페이지에 접근할 수 없으면") {
+                val request = PatchRequest(null, NON_ACCESSIBLE)
+
+                it("NonAccessibleProjectPageException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectPageException> {
+                        objectEventService.updateEvent(USER_ID, NORMAL, request)
+                    }
+                }
+            }
+
+            context("nextPageId의 페이지가 다른 프로젝트에 있는 경우") {
+                val request = PatchRequest(null, OTHER)
+
+                it("LinkNonRelatedPageException 예외를 던진다") {
+                    shouldThrow<LinkNonRelatedPageException> { objectEventService.updateEvent(USER_ID, NORMAL, request) }
                 }
             }
         }
@@ -222,31 +242,19 @@ class ObjectEventServiceTest: DescribeSpec() {
         this.describe("deleteEvent 호출될 때") {
             context("성공적인 경우") {
                 it("반환 값이 없으며, 예외도 던지지 않는다") {
-                    shouldNotThrowAny { objectEventService.deleteEvent(USER_ID, EVENT_ID) }
-                }
-
-                it("해당 ID를 갖는 이벤트의 isDeleted는 true가 된다") {
-                    event.isDeleted shouldBe true
-                }
-
-                it("연결된 오브젝트의 event는 null이 된다") {
-                    pageObject.event shouldBe null
-                }
-
-                it("해당 ID를 갖는 이벤트가 연결된 오브젝트의 deletedEvents로 추가된다") {
-                    pageObject.deletedEvents shouldContain event
+                    shouldNotThrowAny { objectEventService.deleteEvent(USER_ID, NORMAL) }
                 }
             }
 
             context("해당 ID를 갖는 이벤트가 존재하지 않거나 삭제됐으면") {
                 it("ObjectEventNotFoundException 예외를 던진다") {
-                    shouldThrow<ObjectEventNotFoundException> { objectEventService.deleteEvent(USER_ID, NON_EXI_EVENT_ID) }
+                    shouldThrow<ObjectEventNotFoundException> { objectEventService.deleteEvent(USER_ID, DELETED) }
                 }
             }
 
             context("해당 ID를 갖는 PageObject에 접근할 수 없으면") {
                 it("NonAccessibleObjectEventException 예외를 던진다") {
-                    shouldThrow<NonAccessibleObjectEventException> { objectEventService.deleteEvent(USER_ID, NON_ACC_EVENT_ID) }
+                    shouldThrow<NonAccessibleObjectEventException> { objectEventService.deleteEvent(USER_ID, NON_ACCESSIBLE) }
                 }
             }
         }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/event/service/ObjectEventServiceTestWithRepository.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/event/service/ObjectEventServiceTestWithRepository.kt
@@ -1,0 +1,161 @@
+package com.wafflestudio.webgam.domain.event.service
+
+import com.wafflestudio.webgam.TestUtils.Companion.testData1
+import com.wafflestudio.webgam.domain.event.dto.ObjectEventDto.*
+import com.wafflestudio.webgam.domain.event.exception.NonAccessibleObjectEventException
+import com.wafflestudio.webgam.domain.event.exception.ObjectEventNotFoundException
+import com.wafflestudio.webgam.domain.event.model.TransitionType
+import com.wafflestudio.webgam.domain.event.repository.ObjectEventRepository
+import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
+import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@Import(TestQueryDslConfig::class)
+@ActiveProfiles("test")
+@DisplayName("ObjectEvent Service-Repository 테스트")
+class ObjectEventServiceTestWithRepository(
+    private val userRepository: UserRepository,
+    projectPageRepository: ProjectPageRepository,
+    pageObjectEventRepository: PageObjectRepository,
+    private val objectEventRepository: ObjectEventRepository,
+): BehaviorSpec() {
+
+    private val objectEventService = ObjectEventService(projectPageRepository, pageObjectEventRepository, objectEventRepository)
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    override suspend fun afterSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            userRepository.deleteAll()
+        }
+    }
+
+    init {
+        this.Given("testData1") {
+            val data = testData1()
+            userRepository.saveAll(data)
+
+            data.filter { !it.isDeleted }.forEach { user ->
+                val userEvents = user.projects.map { p -> p.pages.map { pp -> pp.objects.map { it.events }
+                    .flatten() }.flatten() }.flatten()
+                val normalEvents = userEvents.filter { !it.isDeleted }
+                val deletedEvents = userEvents.filter { it.isDeleted }
+                val nonAccessibleEvents = data.filter { it.id != user.id }
+                    .map { u -> u.projects.map { p -> p.pages.map { pp -> pp.objects.map { it.events }
+                        .flatten() }.flatten() }.flatten() }.flatten().filter { !it.isDeleted }
+
+                normalEvents.forEach { event ->
+                    When("일반적으로 유저 ID와 이벤트 ID로 조회하면: ${user.username} ${event.`object`.name}") {
+                        val foundEvent = objectEventRepository.findUndeletedObjectEventById(event.id)
+                        val response = shouldNotThrowAny { objectEventService.getEvent(user.id, event.id) }
+                        Then("저장된 이벤트가 조회된다") {
+                            foundEvent shouldBe event
+                            response shouldBe SimpleResponse(event)
+                        }
+                    }
+                }
+
+                deletedEvents.forEach { event ->
+                    When("삭제된 이벤트 접근하면: ${user.username} ${event.`object`.name}") {
+                        Then("ObjectEventNotFoundException 예외가 발생한다") {
+                            shouldThrow<ObjectEventNotFoundException> { objectEventService.getEvent(user.id, event.id) }
+                            shouldThrow<ObjectEventNotFoundException> { objectEventService.updateEvent(user.id, event.id, PatchRequest(null, null)) }
+                            shouldThrow<ObjectEventNotFoundException> { objectEventService.deleteEvent(user.id, event.id) }
+                        }
+                    }
+                }
+
+                nonAccessibleEvents.forEach { event ->
+                    When("접근 권한이 없는 이벤트에 접근하면: ${user.username} ${event.`object`.name}") {
+                        Then("NonAccessibleObjectEventException 예외가 발생한다") {
+                            shouldThrow<NonAccessibleObjectEventException> { objectEventService.getEvent(user.id, event.id) }
+                            shouldThrow<NonAccessibleObjectEventException> { objectEventService.updateEvent(user.id, event.id, PatchRequest(null, null)) }
+                            shouldThrow<NonAccessibleObjectEventException> { objectEventService.deleteEvent(user.id, event.id) }
+                        }
+                    }
+                }
+            }
+
+            When("이벤트를 생성하면") {
+                val user = data.first { it.username == "user-01" }
+                val nextPage = user.projects.first { it.title == "project-01" }.pages.first { it.name == "page-01" }
+                val pageObject = user.projects.first { it.title == "project-01" }.pages.first { it.name == "page-02" }
+                    .objects.first { it.name == "object-02" }
+                val request = CreateRequest(pageObject.id, TransitionType.DEFAULT, nextPage.id)
+                val response = shouldNotThrowAny { objectEventService.createEvent(user.id, request) }
+                val foundEvent = objectEventRepository.findByIdOrNull(response.id)!!
+
+                Then("정상적으로 DB에 저장된다") {
+                    response shouldBe SimpleResponse(foundEvent)
+                    response.transitionType shouldBe request.transitionType
+                    response.nextPage?.id shouldBe request.nextPageId
+                }
+
+                Then("성공적으로 연관관계 매핑이 이루어진다") {
+                    pageObject.events shouldContain foundEvent
+                    pageObject.event shouldBe foundEvent
+                    nextPage.triggeredEvents shouldContain foundEvent
+                }
+            }
+
+            When("이벤트를 수정하면") {
+                val user = data.first { it.username == "user-01" }
+                val nextPage = user.projects.first { it.title == "project-01" }.pages.first { it.name == "page-01" }
+                val event = user.projects.first { it.title == "project-01" }.pages.first { it.name == "page-02" }
+                    .objects.first { it.name == "object-03" }.events.first { !it.isDeleted }
+                val request = PatchRequest(null, nextPage.id)
+
+                nextPage.triggeredEvents shouldNotContain event
+                val response = shouldNotThrowAny { objectEventService.updateEvent(user.id, event.id, request) }
+                val foundEvent = objectEventRepository.findByIdOrNull(response.id)!!
+
+                Then("정상적으로 DB에 저장된다") {
+                    response shouldBe SimpleResponse(foundEvent)
+                    response.nextPage?.id shouldBe request.nextPageId
+                }
+
+                Then("성공적으로 연관관계 매핑이 이루어진다") {
+                    nextPage.triggeredEvents shouldContain foundEvent
+                }
+            }
+
+            When("이벤트를 삭제하면") {
+                val user = data.first { it.username == "user-01" }
+                val event = user.projects.first { it.title == "project-01" }.pages.first { it.name == "page-02" }
+                    .objects.first { it.name == "object-03" }.events.first { !it.isDeleted }
+                shouldNotThrowAny { objectEventService.deleteEvent(user.id, event.id) }
+                val foundEvent = objectEventRepository.findByIdOrNull(event.id)!!
+
+                Then("정상적으로 DB에 저장된다") {
+                    foundEvent shouldBe event
+                    foundEvent.isDeleted shouldBe true
+                }
+
+                Then("이벤트 조회, 수정, 삭제가 더 이상 불가능하다") {
+                    shouldThrow<ObjectEventNotFoundException> { objectEventService.getEvent(user.id, event.id) }
+                    shouldThrow<ObjectEventNotFoundException> { objectEventService.updateEvent(user.id, event.id, PatchRequest(null, null)) }
+                    shouldThrow<ObjectEventNotFoundException> { objectEventService.deleteEvent(user.id, event.id) }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/object/ObjectDescribeSpec.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/object/ObjectDescribeSpec.kt
@@ -2,41 +2,24 @@ package com.wafflestudio.webgam.domain.`object`
 
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.GsonBuilder
-import com.wafflestudio.webgam.ENUM
-import com.wafflestudio.webgam.NUMBER
+import com.wafflestudio.webgam.*
 import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentRequest
 import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentResponse
 import com.wafflestudio.webgam.RestDocsUtils.Companion.requestBody
-import com.wafflestudio.webgam.STRING
-import com.wafflestudio.webgam.domain.event.model.ObjectEvent
-import com.wafflestudio.webgam.domain.event.model.TransitionType
-import com.wafflestudio.webgam.domain.event.repository.ObjectEventRepository
-import com.wafflestudio.webgam.domain.`object`.model.PageObject
 import com.wafflestudio.webgam.domain.`object`.model.PageObjectType
 import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.*
-import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.DEFAULT
-import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
-import com.wafflestudio.webgam.domain.page.model.ProjectPage
-import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
-import com.wafflestudio.webgam.domain.project.model.Project
-import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
-import com.wafflestudio.webgam.domain.user.model.User
 import com.wafflestudio.webgam.domain.user.repository.UserRepository
 import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.*
 import com.wafflestudio.webgam.global.common.exception.ErrorType.Forbidden.*
 import com.wafflestudio.webgam.global.common.exception.ErrorType.NotFound.*
 import com.wafflestudio.webgam.global.security.model.UserPrincipal
 import com.wafflestudio.webgam.global.security.model.WebgamAuthenticationToken
-import com.wafflestudio.webgam.type
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.hamcrest.core.Is.`is`
-import org.junit.jupiter.api.Tag
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -48,143 +31,52 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @ActiveProfiles("test")
-@Tag("Integration-Test")
 @DisplayName("Object 통합 테스트")
 class ObjectDescribeSpec(
-    @Autowired private val mockMvc: MockMvc,
-    @Autowired private val userRepository: UserRepository,
-    @Autowired private val projectRepository: ProjectRepository,
-    @Autowired private val projectPageRepository: ProjectPageRepository,
-    @Autowired private val pageObjectRepository: PageObjectRepository,
-    @Autowired private val objectEventRepository: ObjectEventRepository,
+    private val mockMvc: MockMvc,
+    private val userRepository: UserRepository,
 ): DescribeSpec() {
     override fun extensions() = listOf(SpringExtension)
 
-    final val user = userRepository.save(User("fooId", "foo", "foo@wafflestudio.com", ""))
-    private final val dummyUser = userRepository.save(User("barId", "bar", "bar@wafflestudio.com", ""))
-    private final val auth = WebgamAuthenticationToken(UserPrincipal(user), "")
-    private final val project = projectRepository.save(Project(user, "test-project"))
-    private final val dummyProject = projectRepository.save(Project(dummyUser, "test-project"))
-    private final val page = projectPageRepository.save(ProjectPage(project, "test-page"))
-    private final val dummyPage = projectPageRepository.save(ProjectPage(dummyProject, "test-page"))
-    private final val defaultObject = pageObjectRepository.save(PageObject(page, "default-object", DEFAULT,
-        10, 10, 0, 0, 0, null, null, null, null))
-    private final val dummyObject = pageObjectRepository.save(PageObject(dummyPage, "default-object", DEFAULT,
-        10, 10, 0, 0, 0, null, null, null, null))
-
-    private lateinit var deletedProject: Project
-    private lateinit var deletedPage: ProjectPage
-    private lateinit var deletedObject: PageObject
-
     override suspend fun beforeSpec(spec: Spec) {
-        val p = Project(user, "deleted-project")
-        p.isDeleted = true
-        val pp = ProjectPage(project, "deleted-page")
-        pp.isDeleted = true
-        val po = PageObject(page, "deleted-object", DEFAULT, 10, 10, 0, 0, 0, null, null, null, null)
-        po.isDeleted = true
-
-        withContext(Dispatchers.IO) {
-            deletedProject = projectRepository.save(p)
-            deletedPage = projectPageRepository.save(pp)
-            deletedObject = pageObjectRepository.save(po)
-            objectEventRepository.save(ObjectEvent(defaultObject, null, TransitionType.DEFAULT))
-        }
+        userRepository.saveAll(data)
     }
 
     override suspend fun afterSpec(spec: Spec) {
         withContext(Dispatchers.IO) {
-            pageObjectRepository.deleteAll()
-            projectPageRepository.deleteAll()
-            projectRepository.deleteAll()
             userRepository.deleteAll()
         }
     }
 
     companion object {
         private val gson = GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+        private val data = TestUtils.docTestData()
+        private val auth = WebgamAuthenticationToken(UserPrincipal(data.first()), "")
+        private val project = data.first().projects.first()
+        private val page = project.pages.first()
+        private val pageObject = page.objects.first()
     }
 
     init {
         this.describe("프로젝트 내 오브젝트 조회할 때") {
             context("성공하면") {
-                withContext(Dispatchers.IO) {
-                    val objects = listOf(
-                        PageObject(page, "image-object", IMAGE, 100, 20, 30, 40, 1, null, null, "http://image-source.url", null),
-                        PageObject(page, "text-object", TEXT, 30, 60, -10, -20, 2, "some text", 16, null, null)
-                    )
-                    pageObjectRepository.saveAll(objects)
-                }
-
                 it("200 OK") {
                     mockMvc.perform(
                         get("/api/v1/objects")
                             .param("project-id", project.id.toString())
                             .with(authentication(auth))
                     ).andDo(document(
-                        "get-project-objects/200",
+                        "object/get-list",
                         getDocumentRequest(),
                         getDocumentResponse(),
                         queryParameters(parameterWithName("project-id").description("조회할 프로젝트 ID")),
                     )).andExpect(status().isOk).andDo(print())
-                }
-            }
-
-            context("올바르지 않은 프로젝트 ID일 때") {
-                val errorCode = CONSTRAINT_VIOLATION.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        get("/api/v1/objects")
-                            .param("project-id", "0")
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "get-project-objects/400-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트에 접근하지 못하는 경우") {
-                val errorCode = NON_ACCESSIBLE_PROJECT.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        get("/api/v1/objects")
-                            .param("project-id", dummyProject.id.toString())
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "get-project-objects/403-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트가 없거나 삭제 되었을 때") {
-                val errorCode = PROJECT_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        get("/api/v1/objects")
-                            .param("project-id", deletedProject.id.toString())
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "get-project-objects/404-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
                 }
             }
         }
@@ -212,7 +104,7 @@ class ObjectDescribeSpec(
                             .content(gson.toJson(request))
                             .with(authentication(auth))
                     ).andDo(document(
-                        "create-object/200",
+                        "object/create",
                         getDocumentRequest(),
                         getDocumentResponse(),
                         requestBody(
@@ -231,172 +123,20 @@ class ObjectDescribeSpec(
                     )).andExpect(status().isOk).andDo(print())
                 }
             }
-
-            context("올바르지 않은 값을 넣거나 필수값이 없을 때") {
-                val request = mapOf("page_id" to "0")
-
-                val errorCode = INVALID_FIELD.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        post("/api/v1/objects")
-                            .contentType(APPLICATION_JSON)
-                            .content(gson.toJson(request))
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "create-object/400-0",
-                        getDocumentResponse(),
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("올바르지 않은 타입을 넣을 때") {
-                val request = mapOf("page_id" to "non int")
-
-                val errorCode = JSON_PARSE_ERROR.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        post("/api/v1/objects")
-                            .contentType(APPLICATION_JSON)
-                            .content(gson.toJson(request))
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "create-object/400-1",
-                        getDocumentResponse(),
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 페이지에 접근하지 못하는 경우") {
-                val request = mapOf(
-                    "page_id" to dummyPage.id,
-                    "name" to "create object test: image",
-                    "type" to IMAGE,
-                    "width" to 200,
-                    "height" to 50,
-                    "x_position" to 20,
-                    "y_position" to -10,
-                    "z_index" to 2,
-                    "text_content" to null,
-                    "font_size" to null,
-                    "image_source" to "http://sampe-image.url"
-                )
-
-                val errorCode = NON_ACCESSIBLE_PROJECT_PAGE.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        post("/api/v1/objects")
-                            .contentType(APPLICATION_JSON)
-                            .content(gson.toJson(request))
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "create-object/403-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 페이지가 없거나 삭제 되었을 때") {
-                val request = mapOf(
-                    "page_id" to deletedPage.id,
-                    "name" to "create object test: image",
-                    "type" to IMAGE,
-                    "width" to 200,
-                    "height" to 50,
-                    "x_position" to 20,
-                    "y_position" to -10,
-                    "z_index" to 2,
-                    "text_content" to null,
-                    "font_size" to null,
-                    "image_source" to "http://sampe-image.url"
-                )
-
-                val errorCode = PROJECT_PAGE_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        post("/api/v1/objects")
-                            .contentType(APPLICATION_JSON)
-                            .content(gson.toJson(request))
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "create-object/404-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
         }
 
         this.describe("오브젝트 조회할 때") {
             context("성공하면") {
                 it("200 OK") {
                     mockMvc.perform(
-                        get("/api/v1/objects/{id}", defaultObject.id.toString())
+                        get("/api/v1/objects/{id}", pageObject.id.toString())
                             .with(authentication(auth))
                     ).andDo(document(
-                        "get-object/200",
+                        "object/get",
                         getDocumentRequest(),
                         getDocumentResponse(),
                         pathParameters(parameterWithName("id").description("오브젝트 ID"))
                     )).andExpect(status().isOk).andDo(print())
-                }
-            }
-
-            context("올바르지 않은 오브젝트 ID일 때") {
-                val errorCode = CONSTRAINT_VIOLATION.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        get("/api/v1/objects/{id}", "0")
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "get-object/400-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 오브젝트에 접근하지 못하는 경우") {
-                val errorCode = NON_ACCESSIBLE_PAGE_OBJECT.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        get("/api/v1/objects/{id}", dummyObject.id.toString())
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "get-object/403-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 오브젝트가 없거나 삭제 되었을 때") {
-                val errorCode = PAGE_OBJECT_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        get("/api/v1/objects/{id}", deletedObject.id.toString())
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "get-object/404-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
                 }
             }
         }
@@ -417,12 +157,12 @@ class ObjectDescribeSpec(
 
                 it("200 OK") {
                     mockMvc.perform(
-                        patch("/api/v1/objects/{id}", defaultObject.id.toString())
+                        patch("/api/v1/objects/{id}", pageObject.id.toString())
                             .contentType(APPLICATION_JSON)
                             .content(gson.toJson(request))
                             .with(authentication(auth))
                     ).andDo(document(
-                        "patch-object/200",
+                        "object/patch",
                         getDocumentRequest(),
                         getDocumentResponse(),
                         pathParameters(parameterWithName("id").description("오브젝트 ID")),
@@ -440,168 +180,20 @@ class ObjectDescribeSpec(
                     )).andExpect(status().isOk).andDo(print())
                 }
             }
-
-            context("올바르지 않은 값을 넣을 때") {
-                val request = mapOf("width" to "0")
-
-                val errorCode = INVALID_FIELD.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        patch("/api/v1/objects/{id}", defaultObject.id.toString())
-                            .contentType(APPLICATION_JSON)
-                            .content(gson.toJson(request))
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "patch-object/400-0",
-                        getDocumentResponse(),
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("올바르지 않은 타입을 넣을 때") {
-                val request = mapOf("width" to "non int")
-
-                val errorCode = JSON_PARSE_ERROR.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        patch("/api/v1/objects/{id}", defaultObject.id.toString())
-                            .contentType(APPLICATION_JSON)
-                            .content(gson.toJson(request))
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "patch-object/400-1",
-                        getDocumentResponse(),
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("올바르지 않은 오브젝트 ID일 때") {
-                val request = mapOf("width" to "1")
-
-                val errorCode = CONSTRAINT_VIOLATION.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        patch("/api/v1/objects/{id}", "0")
-                            .contentType(APPLICATION_JSON)
-                            .content(gson.toJson(request))
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "patch-object/400-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 오브젝트에 접근하지 못하는 경우") {
-                val request = mapOf("width" to "1")
-
-                val errorCode = NON_ACCESSIBLE_PAGE_OBJECT.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        patch("/api/v1/objects/{id}", dummyObject.id.toString())
-                            .contentType(APPLICATION_JSON)
-                            .content(gson.toJson(request))
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "patch-object/403-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 오브젝트가 없거나 삭제 되었을 때") {
-                val request = mapOf("width" to "1")
-
-                val errorCode = PAGE_OBJECT_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        patch("/api/v1/objects/{id}", deletedObject.id.toString())
-                            .contentType(APPLICATION_JSON)
-                            .content(gson.toJson(request))
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "patch-object/404-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
         }
 
         this.describe("오브젝트 삭제할 때") {
             context("성공하면") {
                 it("200 OK") {
                     mockMvc.perform(
-                        delete("/api/v1/objects/{id}", defaultObject.id.toString())
+                        delete("/api/v1/objects/{id}", pageObject.id.toString())
                             .with(authentication(auth))
                     ).andDo(document(
-                        "delete-object/200",
+                        "object/delete",
                         getDocumentRequest(),
                         getDocumentResponse(),
                         pathParameters(parameterWithName("id").description("오브젝트 ID")),
                     )).andExpect(status().isOk).andDo(print())
-                }
-            }
-
-            context("올바르지 않은 오브젝트 ID일 때") {
-                val errorCode = CONSTRAINT_VIOLATION.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        delete("/api/v1/objects/{id}", "0")
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "delete-object/400-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 오브젝트에 접근하지 못하는 경우") {
-                val errorCode = NON_ACCESSIBLE_PAGE_OBJECT.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        delete("/api/v1/objects/{id}", dummyObject.id.toString())
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "delete-object/403-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 오브젝트가 없거나 삭제 되었을 때") {
-                val errorCode = PAGE_OBJECT_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                        delete("/api/v1/objects/{id}", deletedObject.id.toString())
-                            .with(authentication(auth))
-                    ).andDo(document(
-                        "delete-object/404-0",
-                        getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", `is`(errorCode))
-                    ).andDo(print())
                 }
             }
         }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/object/service/PageObjectServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/object/service/PageObjectServiceTest.kt
@@ -20,15 +20,10 @@ import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import org.junit.jupiter.api.Tag
 
-@Tag("Unit-Test")
 @DisplayName("PageObjectService 단위 테스트")
 class PageObjectServiceTest : DescribeSpec() {
 
@@ -39,193 +34,154 @@ class PageObjectServiceTest : DescribeSpec() {
         private val pageObjectService = PageObjectService(projectRepository, projectPageRepository, pageObjectRepository)
         private val project = mockk<Project>()
         private val nonAccessibleProject = mockk<Project>()
-        private val page = ProjectPage(project, "test-page")
+        private val page = mockk<ProjectPage>()
         private val nonAccessiblePage = mockk<ProjectPage>()
-        private val pageObject = PageObject(page, "test-object", DEFAULT, 0, 0, 0, 0, 0, "", 0, "", null)
-        private val nonAccessiblePageObject = PageObject(nonAccessiblePage, "test-object", DEFAULT, 0, 0, 0, 0, 0, "", 0, "", null)
-        private val deletedPageObject = mockk<PageObject>()
+        private val pageObject = PageObject(page, "object", DEFAULT, 0, 0, 0, 0, 0, "", 0, "")
+        private val nonAccessiblePageObject = mockk<PageObject>()
+
+        private const val USER_ID = 1L
+        private const val NORMAL = 1L
+        private const val DELETED = 2L
+        private const val NON_ACCESSIBLE = 3L
     }
 
     override suspend fun beforeSpec(spec: Spec) {
-        every { project.isAccessibleTo(any()) } returns true
-        every { nonAccessibleProject.isAccessibleTo(any()) } returns false
-        every { projectPageRepository.findUndeletedProjectPageById(any()) } returns page
-        every { nonAccessiblePage.isAccessibleTo(any()) } returns false
-        every { nonAccessiblePage.id } returns 100
-        every { deletedPageObject.isDeleted } returns true
+        every { projectRepository.findUndeletedProjectById(NORMAL) } returns project
+        every { projectRepository.findUndeletedProjectById(DELETED) } returns null
+        every { projectRepository.findUndeletedProjectById(NON_ACCESSIBLE) } returns nonAccessibleProject
+
+        every { projectPageRepository.findUndeletedProjectPageById(NORMAL) } returns page
+        every { projectPageRepository.findUndeletedProjectPageById(DELETED) } returns null
+        every { projectPageRepository.findUndeletedProjectPageById(NON_ACCESSIBLE) } returns nonAccessiblePage
+
+        every { pageObjectRepository.save(any()) } returns pageObject
+        every { pageObjectRepository.findUndeletedPageObjectById(NORMAL) } returns pageObject
+        every { pageObjectRepository.findUndeletedPageObjectById(DELETED) } returns null
+        every { pageObjectRepository.findUndeletedPageObjectById(NON_ACCESSIBLE) } returns nonAccessiblePageObject
+        every { pageObjectRepository.findAllUndeletedPageObjectsInProject(NORMAL) } returns listOf(pageObject)
+
+        every { project.isAccessibleTo(USER_ID) } returns true
+        every { page.isAccessibleTo(USER_ID) } returns true
+
+        every { nonAccessibleProject.isAccessibleTo(USER_ID) } returns false
+        every { nonAccessiblePage.isAccessibleTo(USER_ID) } returns false
+        every { nonAccessiblePageObject.isAccessibleTo(USER_ID) } returns false
+
+        every { page.id } returns NORMAL
+        every { page.objects } returns mutableListOf()
     }
 
     init {
         this.describe("listProjectObjects 호출될 때") {
             context("성공적인 경우") {
-                every { projectRepository.findUndeletedProjectById(any()) } returns project
-                every { pageObjectRepository.findAllUndeletedPageObjectsInProject(any()) } returns listOf(pageObject, nonAccessiblePageObject)
-
-                val response = withContext(Dispatchers.IO) {
-                    pageObjectService.listProjectObjects(1, 1)
-                }
-
                 it("해당 ID를 갖는 프로젝트에 있는 PageObject들이 Detailed Response DTO로 반환된다") {
-                    response.count shouldBe 1
+                    val response = shouldNotThrowAny { pageObjectService.listProjectObjects(USER_ID, NORMAL) }
                     response.data shouldContain DetailedResponse(pageObject)
-                }
-
-                it("접근 불가능한 PageObject들은 제외된다") {
-                    response.data shouldNotContain DetailedResponse(nonAccessiblePageObject)
                 }
             }
 
             context("해당 ID를 갖는 프로젝트가 존재하지 않거나 삭제됐으면") {
-                every { projectRepository.findUndeletedProjectById(any()) } returns null
-
                 it("ProjectNotFoundException 예외를 던진다") {
-                    shouldThrow<ProjectNotFoundException> { pageObjectService.listProjectObjects(1, 1) }
+                    shouldThrow<ProjectNotFoundException> { pageObjectService.listProjectObjects(USER_ID, DELETED) }
                 }
             }
 
             context("해당 ID를 갖는 프로젝트에 접근할 수 없으면") {
-                every { projectRepository.findUndeletedProjectById(any()) } returns nonAccessibleProject
-
                 it("NonAccessibleProjectException 예외를 던진다") {
-                    shouldThrow<NonAccessibleProjectException> { pageObjectService.listProjectObjects(1, 1) }
+                    shouldThrow<NonAccessibleProjectException> { pageObjectService.listProjectObjects(USER_ID, NON_ACCESSIBLE) }
                 }
             }
         }
 
         this.describe("getObject 호출될 때") {
             context("성공적인 경우") {
-                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns pageObject
-
-                val response = withContext(Dispatchers.IO) {
-                    pageObjectService.getObject(1, 1)
-                }
-
                 it("PageObject가 Detailed Response DTO로 반환된다") {
+                    val response = shouldNotThrowAny { pageObjectService.getObject(USER_ID, NORMAL) }
                     response shouldBe DetailedResponse(pageObject)
                 }
             }
 
             context("해당 ID를 갖는 PageObject가 존재하지 않거나 삭제됐으면") {
-                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns null
-
                 it("PageObjectNotFoundException 예외를 던진다") {
-                    shouldThrow<PageObjectNotFoundException> { pageObjectService.getObject(1, 1) }
+                    shouldThrow<PageObjectNotFoundException> { pageObjectService.getObject(USER_ID, DELETED) }
                 }
             }
 
             context("해당 ID를 갖는 PageObject에 접근할 수 없으면") {
-                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns nonAccessiblePageObject
-
                 it("NonAccessiblePageObjectException 예외를 던진다") {
-                    shouldThrow<NonAccessiblePageObjectException> { pageObjectService.getObject(1, 1) }
+                    shouldThrow<NonAccessiblePageObjectException> { pageObjectService.getObject(USER_ID, NON_ACCESSIBLE) }
                 }
             }
         }
 
         this.describe("createObject 호출될 때") {
-            val request = CreateRequest(0, "", DEFAULT, 0, 0, 0, 0, 0, "", 0, "")
-
             context("성공적인 경우") {
-                every { projectPageRepository.findUndeletedProjectPageById(any()) } returns page
-                every { pageObjectRepository.save(any()) } returns pageObject
-
-                val response = withContext(Dispatchers.IO) {
-                    pageObjectService.createObject(1, request)
-                }
+                val request = CreateRequest(NORMAL, "create-object", DEFAULT, 0, 0, 0, 0, 0, "", 0, "")
 
                 it("생성된 PageObject가 SimpleResponse DTO로 반환된다") {
+                    val response = shouldNotThrowAny { pageObjectService.createObject(USER_ID, request) }
                     response shouldBe SimpleResponse(pageObject)
                 }
             }
 
             context("해당 ID를 갖는 페이지가 존재하지 않거나 삭제됐으면") {
-                every { projectPageRepository.findUndeletedProjectPageById(any()) } returns null
+                val request = CreateRequest(DELETED, "create-object", DEFAULT, 0, 0, 0, 0, 0, "", 0, "")
 
                 it("ProjectPageNotFoundException 예외를 던진다") {
-                    shouldThrow<ProjectPageNotFoundException> { pageObjectService.createObject(1, request) }
+                    shouldThrow<ProjectPageNotFoundException> { pageObjectService.createObject(USER_ID, request) }
                 }
             }
 
             context("해당 ID를 갖는 페이지에 접근할 수 없으면") {
-                every { projectPageRepository.findUndeletedProjectPageById(any()) } returns nonAccessiblePage
+                val request = CreateRequest(NON_ACCESSIBLE, "create-object", DEFAULT, 0, 0, 0, 0, 0, "", 0, "")
 
                 it("NonAccessibleProjectPageException 예외를 던진다") {
-                    shouldThrow<NonAccessibleProjectPageException> { pageObjectService.createObject(1, request) }
+                    shouldThrow<NonAccessibleProjectPageException> { pageObjectService.createObject(USER_ID, request) }
                 }
             }
         }
 
         this.describe("modifyObject 호출될 때") {
-            pageObject.width = 20
-            pageObject.height = 10
             val request = PatchRequest(null, 30, null, null, null, null, null, null, null)
 
             context("성공적인 경우") {
-                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns pageObject
-
-                val response = withContext(Dispatchers.IO) {
-                    pageObjectService.modifyObject(1, 1, request)
-                }
-
                 it("수정된 PageObject가 Detailed Response DTO로 반환된다") {
+                    val response = shouldNotThrowAny { pageObjectService.modifyObject(USER_ID, NORMAL, request) }
                     response shouldBe DetailedResponse(pageObject)
-                }
-
-                it("request의 값으로 수정된다") {
-                    response.width shouldBe 30
-                }
-
-                it("request의 NULL은 수정되지 않는다") {
-                    response.height shouldBe 10
                 }
             }
 
             context("해당 ID를 갖는 PageObject가 존재하지 않거나 삭제됐으면") {
-                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns null
-
                 it("PageObjectNotFoundException 예외를 던진다") {
-                    shouldThrow<PageObjectNotFoundException> { pageObjectService.modifyObject(1, 1, request) }
+                    shouldThrow<PageObjectNotFoundException> { pageObjectService.modifyObject(USER_ID, DELETED, request) }
                 }
             }
 
             context("해당 ID를 갖는 PageObject에 접근할 수 없으면") {
-                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns nonAccessiblePageObject
-
                 it("NonAccessiblePageObjectException 예외를 던진다") {
-                    shouldThrow<NonAccessiblePageObjectException> { pageObjectService.modifyObject(1, 1, request) }
+                    shouldThrow<NonAccessiblePageObjectException> { pageObjectService.modifyObject(USER_ID, NON_ACCESSIBLE, request) }
                 }
             }
         }
 
         this.describe("deleteObject 호출될 때") {
             context("성공적인 경우") {
-                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns pageObject
-
                 it("반환 값이 없으며, 예외도 던지지 않는다") {
-                    shouldNotThrowAny { pageObjectService.deleteObject(1, 1) }
-                }
-
-                it("해당 PageObject의 isDeleted는 true가 된다") {
-                    pageObject.isDeleted shouldBe true
+                    shouldNotThrowAny { pageObjectService.deleteObject(USER_ID, NORMAL) }
                 }
             }
 
             context("해당 ID를 갖는 PageObject가 존재하지 않거나 삭제됐으면") {
-                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns null
-
                 it("PageObjectNotFoundException 예외를 던진다") {
-                    shouldThrow<PageObjectNotFoundException> { pageObjectService.deleteObject(1, 1) }
+                    shouldThrow<PageObjectNotFoundException> { pageObjectService.deleteObject(USER_ID, DELETED) }
                 }
             }
 
             context("해당 ID를 갖는 PageObject에 접근할 수 없으면") {
-                every { pageObjectRepository.findUndeletedPageObjectById(any()) } returns nonAccessiblePageObject
-
                 it("NonAccessiblePageObjectException 예외를 던진다") {
-                    shouldThrow<NonAccessiblePageObjectException> { pageObjectService.deleteObject(1, 1) }
+                    shouldThrow<NonAccessiblePageObjectException> { pageObjectService.deleteObject(USER_ID, NON_ACCESSIBLE) }
                 }
             }
         }
     }
-
 }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/object/service/PageObjectServiceTestWithRepository.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/object/service/PageObjectServiceTestWithRepository.kt
@@ -1,0 +1,260 @@
+package com.wafflestudio.webgam.domain.`object`.service
+
+import com.wafflestudio.webgam.TestUtils.Companion.makeFieldList
+import com.wafflestudio.webgam.TestUtils.Companion.testData1
+import com.wafflestudio.webgam.domain.event.repository.ObjectEventRepository
+import com.wafflestudio.webgam.domain.`object`.dto.PageObjectDto.*
+import com.wafflestudio.webgam.domain.`object`.exception.NonAccessiblePageObjectException
+import com.wafflestudio.webgam.domain.`object`.exception.PageObjectNotFoundException
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.IMAGE
+import com.wafflestudio.webgam.domain.`object`.model.PageObjectType.TEXT
+import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
+import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.project.exception.ProjectNotFoundException
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.collections.shouldNotContainAnyOf
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@Import(TestQueryDslConfig::class)
+@ActiveProfiles("test")
+@DisplayName("PageObject Service-Repository 테스트")
+class PageObjectServiceTestWithRepository(
+    private val userRepository: UserRepository,
+    projectRepository: ProjectRepository,
+    projectPageRepository: ProjectPageRepository,
+    private val pageObjectRepository: PageObjectRepository,
+    private val objectEventRepository: ObjectEventRepository,
+): BehaviorSpec() {
+
+    private val pageObjectService = PageObjectService(projectRepository, projectPageRepository, pageObjectRepository)
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    override suspend fun afterSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            userRepository.deleteAll()
+        }
+    }
+
+    init {
+        this.Given("testData1") {
+            val data = testData1()
+            userRepository.saveAll(data)
+
+            data.filter { !it.isDeleted }.forEach { user ->
+                user.projects.filter { !it.isDeleted }.forEach { project ->
+                    When("프로젝트 내 오브젝트 전체 목록을 조회하면: ${user.username} ${project.title}") {
+                        val normalObjects = project.pages.map { it.objects }.flatten().filter { !it.isDeleted && it.isAccessibleTo(user.id) }
+                        val deletedObjects = project.pages.map { it.objects }.flatten().filter { it.isDeleted }
+                        val nonAccessibleObjects = project.pages.map { it.objects }.flatten().filter { !it.isDeleted && !it.isAccessibleTo(user.id) }
+                        val response = shouldNotThrowAny { pageObjectService.listProjectObjects(user.id, project.id) }
+
+                        Then("삭제되지 않은 모든 오브젝트들이 목록으로 조회된다") {
+                            response.data shouldContainExactlyInAnyOrder normalObjects.map { DetailedResponse(it) }
+                            response.count shouldBe normalObjects.size
+                        }
+                        Then("삭제된 모든 오브젝트들은 목록에 포함되지 않는다") {
+                            if (deletedObjects.isNotEmpty())
+                                response.data shouldNotContainAnyOf deletedObjects.map { DetailedResponse(it) }
+                        }
+                        Then("접근 불가능한 오브젝트들은 목록에 포함되지 않는다") {
+                            if (nonAccessibleObjects.isNotEmpty())
+                                response.data shouldNotContainAnyOf nonAccessibleObjects.map { DetailedResponse(it) }
+                        }
+                    }
+                }
+            }
+
+            data.filter { !it.isDeleted }.forEach { user ->
+                user.projects.filter { it.isDeleted }.forEach { project ->
+                    When("삭제된 프로젝트 내 오브젝트 전체 목록을 조회하면: ${user.username} ${project.title}") {
+                        Then("ProjectNotFoundException 예외가 발생한다") {
+                            shouldThrow<ProjectNotFoundException> { pageObjectService.listProjectObjects(user.id, project.id) }
+                        }
+                    }
+                }
+            }
+
+            data.filter { !it.isDeleted }.forEach { user ->
+                val userObjects = user.projects.map { p -> p.pages.map { it.objects }.flatten() }.flatten()
+                val normalObjects = userObjects.filter { !it.isDeleted }
+                val deletedObjects = userObjects.filter { it.isDeleted }
+                val nonAccessibleObjects = data.filter { it.id != user.id }.map { u -> u.projects.map { p -> p.pages.map { it.objects }
+                    .flatten() }.flatten() }.flatten().filter { !it.isDeleted }
+
+                normalObjects.forEach { pageObject ->
+                    When("일반적으로 유저 ID와 오브젝트 ID로 조회하면: ${user.username} ${pageObject.name}") {
+                        val foundObject = pageObjectRepository.findUndeletedPageObjectById(pageObject.id)
+                        val response = shouldNotThrowAny { pageObjectService.getObject(user.id, pageObject.id) }
+
+                        Then("저장된 오브젝트가 조회된다") {
+                            foundObject shouldBe pageObject
+                            response shouldBe DetailedResponse(pageObject)
+                        }
+                    }
+                }
+
+                deletedObjects.forEach { pageObject ->
+                    When("삭제된 오브젝트 접근하면: ${user.username} ${pageObject.name}") {
+                        Then("PageObjectNotFoundException 예외가 발생한다") {
+                            shouldThrow<PageObjectNotFoundException> {
+                                pageObjectService.getObject(user.id, pageObject.id)
+                            }
+                            shouldThrow<PageObjectNotFoundException> {
+                                val request = PatchRequest(null, null, null, null, null, null, null, null, null)
+                                pageObjectService.modifyObject(user.id, pageObject.id, request)
+                            }
+                            shouldThrow<PageObjectNotFoundException> {
+                                pageObjectService.deleteObject(user.id, pageObject.id)
+                            }
+                        }
+                    }
+                }
+
+                nonAccessibleObjects.forEach { pageObject ->
+                    When("접근 권한이 없는 오브젝트에 접근하면: ${user.username} ${pageObject.name}") {
+                        Then("NonAccessiblePageObjectException 예외가 발생한다") {
+                            shouldThrow<NonAccessiblePageObjectException> {
+                                pageObjectService.getObject(user.id, pageObject.id)
+                            }
+                            shouldThrow<NonAccessiblePageObjectException> {
+                                val request = PatchRequest(null, null, null, null, null, null, null, null, null)
+                                pageObjectService.modifyObject(user.id, pageObject.id, request)
+                            }
+                            shouldThrow<NonAccessiblePageObjectException> {
+                                pageObjectService.deleteObject(user.id, pageObject.id)
+                            }
+                        }
+                    }
+                }
+            }
+
+            When("오브젝트를 생성하면") {
+                val user = data.first { it.username == "user-01" }
+                val page = user.projects.first { it.title == "project-01" }.pages.first { it.name == "page-01" }
+                val request = CreateRequest(page.id, "create-object", TEXT, 25, 35, 10, -30, 1, "object-text", 16, null)
+                val response = shouldNotThrowAny { pageObjectService.createObject(user.id, request) }
+                val foundObject = pageObjectRepository.findByIdOrNull(response.id)!!
+
+                Then("정상적으로 DB에 저장된다") {
+                    response shouldBe SimpleResponse(foundObject)
+                    response.name shouldBe request.name
+                    response.type shouldBe request.type
+                    response.width shouldBe request.width
+                    response.height shouldBe request.height
+                    response.xPosition shouldBe request.xPosition
+                    response.yPosition shouldBe request.yPosition
+                    response.zIndex shouldBe request.zIndex
+                    response.textContent shouldBe request.textContent
+                    response.fontSize shouldBe request.fontSize
+                    response.imageSource shouldBe request.imageSource
+                }
+
+                Then("성공적으로 연관관계 매핑이 이루어진다") {
+                    page.objects shouldContain foundObject
+                }
+            }
+
+            When("오브젝트를 수정하면") {
+                val user = data.first { it.username == "user-01" }
+                val pageObject = user.projects.first { it.title == "project-01" }.pages.first { it.name == "page-02" }.objects.first { it.name == "object-01" }
+                val combinations = makeFieldList(
+                    listOf(null, IMAGE, TEXT).map { it to null },
+                    listOf(null, 11).map { it to null },
+                    listOf(null, 22).map { it to null },
+                    listOf(null, -80).map { it to null },
+                    listOf(null, 28).map { it to null },
+                    listOf(null, 8).map { it to null },
+                    listOf(null, "patch-text").map { it to null },
+                    listOf(null, 20).map { it to null },
+                    listOf(null, "patch-image-source").map { it to null },
+                )
+                combinations.forAll { (l, _) ->
+                    val request = PatchRequest(
+                        l[0] as PageObjectType?,
+                        l[1] as Int?,
+                        l[2] as Int?,
+                        l[3] as Int?,
+                        l[4] as Int?,
+                        l[5] as Int?,
+                        l[6] as String?,
+                        l[7] as Int?,
+                        l[8] as String?
+                    )
+                    val beforeUpdate = DetailedResponse(pageObject)
+                    val response = shouldNotThrowAny { pageObjectService.modifyObject(user.id, pageObject.id, request) }
+                    val foundObject = pageObjectRepository.findByIdOrNull(pageObject.id)!!
+
+                    Then("NULL이 아닌 값들은 정상적으로 DB에 반영된다") {
+                        foundObject shouldBe pageObject
+                        response shouldBe DetailedResponse(foundObject)
+                        response.type shouldBe (request.type ?: beforeUpdate.type)
+                        response.width shouldBe (request.width ?: beforeUpdate.width)
+                        response.height shouldBe (request.height ?: beforeUpdate.height)
+                        response.xPosition shouldBe (request.xPosition ?: beforeUpdate.xPosition)
+                        response.yPosition shouldBe (request.yPosition ?: beforeUpdate.yPosition)
+                        response.zIndex shouldBe (request.zIndex ?: beforeUpdate.zIndex)
+                        response.textContent shouldBe (request.textContent ?: beforeUpdate.textContent)
+                        response.fontSize shouldBe (request.fontSize ?: beforeUpdate.fontSize)
+                        response.imageSource shouldBe (request.imageSource ?: beforeUpdate.imageSource)
+                    }
+                }
+            }
+
+            When("오브젝트를 삭제하면") {
+                val user = data.first { it.username == "user-01" }
+                val pageObject = user.projects.first { it.title == "project-01" }.pages.first { it.name == "page-02" }.objects.first { it.name == "object-01" }
+                shouldNotThrowAny { pageObjectService.deleteObject(user.id, pageObject.id) }
+                val foundObject = pageObjectRepository.findByIdOrNull(pageObject.id)!!
+
+                Then("정상적으로 DB에 반영된다") {
+                    foundObject shouldBe pageObject
+                    foundObject.isDeleted shouldBe true
+                }
+
+                Then("오브젝트 조회, 수정, 삭제가 더 이상 불가능하다") {
+                    shouldThrow<PageObjectNotFoundException> { pageObjectService.getObject(user.id, pageObject.id) }
+                    shouldThrow<PageObjectNotFoundException> { pageObjectService.modifyObject(user.id, pageObject.id,
+                        PatchRequest(null, null, null, null, null, null, null, null, null)) }
+                    shouldThrow<PageObjectNotFoundException> { pageObjectService.deleteObject(user.id, pageObject.id) }
+                }
+
+                Then("프로젝트 내 모든 오브젝트 목록 조회에서도 제외된다") {
+                    val response = shouldNotThrowAny { pageObjectService.listProjectObjects(user.id, pageObject.page.project.id) }
+                    response.data shouldNotContain DetailedResponse(pageObject)
+                }
+
+                Then("하위 이벤트들도 삭제된다") {
+                    pageObject.events.forEach { event ->
+                        val foundEvent = objectEventRepository.findUndeletedObjectEventById(event.id)!!
+
+                        foundEvent shouldBe event
+                        foundEvent.isDeleted shouldBe true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/page/PageDescribeSpec.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/page/PageDescribeSpec.kt
@@ -2,176 +2,89 @@ package com.wafflestudio.webgam.domain.page
 
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.GsonBuilder
-import com.wafflestudio.webgam.NUMBER
-import com.wafflestudio.webgam.RestDocsUtils
-import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentResponse
+import com.wafflestudio.webgam.*
 import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentRequest
-import com.wafflestudio.webgam.STRING
-import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto
-import com.wafflestudio.webgam.domain.page.model.ProjectPage
-import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
-import com.wafflestudio.webgam.domain.project.model.Project
-import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
-import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentResponse
 import com.wafflestudio.webgam.domain.user.repository.UserRepository
-import com.wafflestudio.webgam.global.common.exception.ErrorType
 import com.wafflestudio.webgam.global.security.model.UserPrincipal
 import com.wafflestudio.webgam.global.security.model.WebgamAuthenticationToken
-import com.wafflestudio.webgam.type
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.hamcrest.core.Is
-import org.junit.jupiter.api.Tag
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
-import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @ActiveProfiles("test")
-@Tag("Integration-Test")
 @DisplayName("Page 통합 테스트")
 class PageDescribeSpec (
-        @Autowired private val mockMvc: MockMvc,
-        @Autowired private val userRepository: UserRepository,
-        @Autowired private val projectRepository: ProjectRepository,
-        @Autowired private val projectPageRepository: ProjectPageRepository,
+    private val mockMvc: MockMvc,
+    private val userRepository: UserRepository,
 ): DescribeSpec(){
 
     override fun extensions() = listOf(SpringExtension)
 
-    final val user = userRepository.save(User("fooId", "foo", "foo@wafflestudio.com", ""))
-    private final val dummyUser = userRepository.save(User("barId", "bar", "bar@wafflestudio.com", ""))
-    private final val auth = WebgamAuthenticationToken(UserPrincipal(user), "")
-    private final val project = projectRepository.save(Project(user, "test-project"))
-    private final val dummyProject = projectRepository.save(Project(dummyUser, "test-project"))
-    private final val page = projectPageRepository.save(ProjectPage(project, "test-page"))
-    private final val dummyPage = projectPageRepository.save(ProjectPage(dummyProject, "test-page"))
-
-    private lateinit var deletedProject: Project
-    private lateinit var deletedPage: ProjectPage
-
     override suspend fun beforeSpec(spec: Spec) {
-        val p = Project(user, "deleted-project")
-        p.isDeleted = true
-        val pp = ProjectPage(project, "deleted-page")
-        pp.isDeleted = true
-
-        withContext(Dispatchers.IO) {
-            deletedProject = projectRepository.save(p)
-            deletedPage = projectPageRepository.save(pp)
-        }
+        userRepository.saveAll(data)
     }
 
     override suspend fun afterSpec(spec: Spec) {
         withContext(Dispatchers.IO) {
-            projectPageRepository.deleteAll()
-            projectRepository.deleteAll()
             userRepository.deleteAll()
         }
     }
 
     companion object {
         private val gson = GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
-        //private val validCreateRequest = ProjectPageDto.CreateRequest(1, "page_name") // project.id
-        private val validPatchRequest = ProjectPageDto.PatchRequest("page_name_changed")
+        private val data = TestUtils.docTestData()
+        private val auth = WebgamAuthenticationToken(UserPrincipal(data.first()), "")
+        private val project = data.first().projects.first()
+        private val page = project.pages.first()
     }
 
     init{
-        this.describe("프로젝트 페이지 조회할 때"){
+        this.describe("프로젝트 페이지 조회할 때") {
             context("성공하면") {
                 it("200 OK") {
-                    mockMvc.perform(get("/api/v1/page/{id}", page.id.toString())
+                    mockMvc.perform(get("/api/v1/pages/{id}", page.id)
                             .with(authentication(auth))
                     ).andDo(document(
-                            "get-project-page/200",
+                            "page/get",
                             getDocumentRequest(),
                             getDocumentResponse(),
                             pathParameters(parameterWithName("id").description("프로젝트 페이지 ID")),
                     )).andExpect(status().isOk).andDo(print())
                 }
             }
-
-            context("올바르지 않은 프로젝트 페이지 ID일 때") {
-                val errorCode = ErrorType.BadRequest.CONSTRAINT_VIOLATION.code()
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            get("/api/v1/page/{id}", "0")
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "get-project-page/400-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트 페이지에 접근하지 못하는 경우") {
-                val errorCode = ErrorType.Forbidden.NON_ACCESSIBLE_PROJECT_PAGE.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            get("/api/v1/page/{id}", dummyPage.id.toString())
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "get-project-page/403-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트가 없거나 삭제 되었을 때") {
-                val errorCode = ErrorType.NotFound.PROJECT_PAGE_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            get("/api/v1/page/{id}", deletedPage.id.toString())
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "get-project-page/404-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
         }
 
         this.describe("프로젝트 페이지 생성할 때") {
             context("성공하면") {
-                val request = mapOf("project_id" to 1, "name" to "name")
+                val request = mapOf("project_id" to project.id, "name" to "create-page")
 
                 it("200 OK") {
-                    mockMvc.perform(post("/api/v1/page")
+                    mockMvc.perform(post("/api/v1/pages")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(gson.toJson(request))
                             .with(authentication(auth))
                     ).andDo(document(
-                            "create-project-page/200",
+                            "page/create",
                             getDocumentRequest(),
                             getDocumentResponse(),
                             RestDocsUtils.requestBody(
@@ -181,103 +94,19 @@ class PageDescribeSpec (
                     )).andExpect(status().isOk).andDo(print())
                 }
             }
-
-            context("올바르지 않은 값을 넣거나 필수값이 없을 때") {
-                val request = mapOf("project_id" to 0L)
-
-                val errorCode = ErrorType.BadRequest.INVALID_FIELD.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            post("/api/v1/page")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(request))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "create-project-page/400-0",
-                            getDocumentResponse(),
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("올바르지 않은 타입을 넣을 때") {
-                val request = mapOf("project_id" to "non int", "name" to "page")
-
-                val errorCode = ErrorType.BadRequest.JSON_PARSE_ERROR.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            post("/api/v1/page")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(request))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "create-project-page/400-1",
-                            getDocumentResponse(),
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트에 접근하지 못하는 경우") {
-                val request = mapOf(
-                        "project_id" to dummyProject.id,
-                        "name" to "create page test"
-                )
-
-                val errorCode = ErrorType.Forbidden.NON_ACCESSIBLE_PROJECT.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            post("/api/v1/page")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(request))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "create-project-page/403-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트가 없거나 삭제 되었을 때") {
-                val request = mapOf(
-                        "project_id" to deletedProject.id,
-                        "name" to "create page test"
-                )
-
-                val errorCode = ErrorType.NotFound.PROJECT_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            post("/api/v1/page")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(request))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "create-project-page/404-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
         }
 
         this.describe("프로젝트 페이지 수정할 때") {
             context("성공하면") {
+                val request = mapOf("name" to "patch-page")
+
                 it("200 OK") {
-                    mockMvc.perform(patch("/api/v1/page/{id}", page.id.toString())
+                    mockMvc.perform(patch("/api/v1/pages/{id}", page.id)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(gson.toJson(validPatchRequest))
+                            .content(gson.toJson(request))
                             .with(authentication(auth))
                     ).andDo(document(
-                            "patch-project-page/200",
+                            "page/patch",
                             getDocumentRequest(),
                             getDocumentResponse(),
                             pathParameters(parameterWithName("id").description("프로젝트 페이지 ID")),
@@ -287,127 +116,22 @@ class PageDescribeSpec (
                     )).andExpect(status().isOk).andDo(print())
                 }
             }
-
-            context("올바르지 않은 페이지 ID일 때") {
-                val errorCode = ErrorType.BadRequest.CONSTRAINT_VIOLATION.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            patch("/api/v1/page/{id}", "0")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(validPatchRequest))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "patch-project-page/400-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 페이지에 접근하지 못하는 경우") {
-
-                val errorCode = ErrorType.Forbidden.NON_ACCESSIBLE_PROJECT_PAGE.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            patch("/api/v1/page/{id}", dummyPage.id.toString())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(validPatchRequest))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "patch-project-page/403-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 페이지가 없거나 삭제 되었을 때") {
-                val errorCode = ErrorType.NotFound.PROJECT_PAGE_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            patch("/api/v1/page/{id}", deletedPage.id.toString())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(validPatchRequest))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "patch-project-page/404-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
         }
 
         this.describe("프로젝트 페이지 삭제할 때") {
             context("성공하면") {
                 it("200 OK") {
                     mockMvc.perform(
-                            delete("/api/v1/page/{id}", page.id.toString())
+                            delete("/api/v1/pages/{id}", page.id.toString())
                                     .with(authentication(auth))
                     ).andDo(document(
-                            "delete-project-page/200",
+                            "page/delete",
                             getDocumentRequest(),
                             getDocumentResponse(),
                             pathParameters(parameterWithName("id").description("프로젝트 페이지 ID")),
                     )).andExpect(status().isOk).andDo(print())
                 }
             }
-
-            context("올바르지 않은 페이지 ID일 때") {
-                val errorCode = ErrorType.BadRequest.CONSTRAINT_VIOLATION.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            delete("/api/v1/page/{id}", "0")
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "delete-project-page/400-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 페이지에 접근하지 못하는 경우") {
-                val errorCode = ErrorType.Forbidden.NON_ACCESSIBLE_PROJECT_PAGE.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            delete("/api/v1/page/{id}", dummyPage.id.toString())
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "delete-project-page/403-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 페이지가 없거나 삭제 되었을 때") {
-                val errorCode = ErrorType.NotFound.PROJECT_PAGE_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            delete("/api/v1/page/{id}", deletedPage.id.toString())
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "delete-project-page/404-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
         }
-
     }
-
 }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/page/controller/ProjectPageControllerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/page/controller/ProjectPageControllerTest.kt
@@ -1,4 +1,203 @@
 package com.wafflestudio.webgam.domain.page.controller
 
-class ProjectPageControllerTest {
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.webgam.TestUtils
+import com.wafflestudio.webgam.TestUtils.Companion.pathVariableIds
+import com.wafflestudio.webgam.TestUtils.Companion.testData1
+import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.DetailedResponse
+import com.wafflestudio.webgam.domain.page.service.ProjectPageService
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.INVALID_FIELD
+import com.wafflestudio.webgam.global.common.exception.ErrorType.BadRequest.JSON_PARSE_ERROR
+import com.wafflestudio.webgam.global.security.model.UserPrincipal
+import com.wafflestudio.webgam.global.security.model.WebgamAuthenticationToken
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.mockk.every
+import io.mockk.justRun
+import org.hamcrest.core.Is
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.*
+
+@WebMvcTest(ProjectPageController::class)
+@MockkBean(JpaMetamodelMappingContext::class)
+@ActiveProfiles("test")
+@DisplayName("ProjectPageController 테스트")
+class ProjectPageControllerTest(
+    private val mockMvc: MockMvc,
+    @MockkBean private val projectPageService: ProjectPageService,
+): DescribeSpec() {
+
+    companion object {
+        private val gson = GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+        private val user = testData1().first()
+        private val authentication = WebgamAuthenticationToken(UserPrincipal(user), "")
+        private val page = user.projects.first().pages.first()
+
+        /* Test Parameters */
+        private val ids = pathVariableIds()
+    }
+
+    override suspend fun beforeSpec(spec: Spec) {
+        every { projectPageService.createProjectPage(any(), any()) } returns DetailedResponse(page)
+        every { projectPageService.getProjectPage(any(), any()) } returns DetailedResponse(page)
+        every { projectPageService.patchProjectPage(any(), any(), any()) } returns DetailedResponse(page)
+        justRun { projectPageService.deleteProjectPage(any(), any()) }
+    }
+
+    init {
+        this.describe("페이지 생성할 때") {
+            val projectIds = listOf(
+                listOf(1, 3, 4, 10).map { it to null },
+                listOf(-1, 0, null).map { it to INVALID_FIELD.code() },
+                listOf("nonInt").map { it to JSON_PARSE_ERROR.code() }).flatten()
+            val names = listOf(
+                listOf("valid-page-name").map { it to null },
+                listOf(null, "", "   ").map { it to INVALID_FIELD.code() }).flatten()
+
+            val combinations = TestUtils.makeFieldList(projectIds, names)
+
+            val fields = listOf("project_id", "name")
+
+            combinations.forAll { (l, t) ->
+                val (idx, code) = t
+                val request = l.mapIndexed { index, field -> fields[index] to field }.toMap()
+
+                when (idx) {
+                    -1 -> { context("Body의 모든 field가 올바르면") {
+                        it("200 OK") {
+                            mockMvc.post("/api/v1/pages") {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect { status { isOk() } }
+                        }
+                    } }
+                    else -> { context("${fields[idx]}가 올바르지 않은 값 '${l[idx]}' 이면") {
+                        it ("400 Bad Request, 에러코드 $code") {
+                            mockMvc.post("/api/v1/pages") {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect {
+                                status { isBadRequest() }
+                                jsonPath("$.error_code", Is.`is`(code))
+                            }
+                        }
+                    } }
+                }
+            }
+        }
+
+        this.describe("특정 페이지 조회할 때") {
+            val ids = TestUtils.makeFieldList(ids)
+
+            ids.forAll { (i, t) ->
+                val (idx, code) = t
+                val id = i[0].toString()
+
+                if (idx == -1) context("ID가 올바른 값 '${id}'이면") {
+                    it("200 OK") {
+                        mockMvc.get("/api/v1/pages/{id}", id) {
+                            param("project-id", id)
+                            with(authentication(authentication))
+                        }.andExpect { status { isOk() } }
+                    }
+                }
+                else context("ID가 올바르지 않은 값 '${id}'이면") {
+                    it("400 Bad Request, 에러코드 $code") {
+                        mockMvc.get("/api/v1/pages/{id}", id) {
+                            param("project-id", id)
+                            with(authentication(authentication))
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", Is.`is`(code))
+                        }
+                    }
+                }
+            }
+        }
+
+        this.describe("특정 페이지 수정할 때") {
+            val names = listOf(
+                listOf("valid-page-name").map { it to null },
+                listOf(null, "", "   ").map { it to INVALID_FIELD.code() }).flatten()
+
+            val combinations = TestUtils.makeFieldList(ids, names)
+
+            val fields = listOf("id", "name")
+
+            combinations.forAll { (l, t) ->
+                val (idx, code) = t
+                val request = mapOf(
+                    "name" to l[1]
+                )
+
+                when (idx) {
+                    -1 -> { context("Body의 모든 field가 올바르면") {
+                        it("200 OK") {
+                            mockMvc.patch("/api/v1/pages/{id}", l[0]) {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect { status { isOk() } }
+                        }
+                    } }
+                    else -> { context("${fields[idx]}가 올바르지 않은 값 '${l[idx]}' 이면") {
+                        it ("400 Bad Request, 에러코드 $code") {
+                            mockMvc.patch("/api/v1/pages/{id}", l[0]) {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect {
+                                status { isBadRequest() }
+                                jsonPath("$.error_code", Is.`is`(code))
+                            }
+                        }
+                    } }
+                }
+            }
+        }
+
+        this.describe("특정 페이지 삭제할 때") {
+            val ids = TestUtils.makeFieldList(ids)
+
+            ids.forAll { (i, t) ->
+                val (idx, code) = t
+                val id = i[0].toString()
+
+                if (idx == -1) context("ID가 올바른 값 '${id}'이면") {
+                    it("200 OK") {
+                        mockMvc.delete("/api/v1/pages/{id}", id) {
+                            with(authentication(authentication))
+                            with(csrf())
+                        }.andExpect { status { isOk() } }
+                    }
+                }
+                else context("ID가 올바르지 않은 값 '${id}'이면") {
+                    it("400 Bad Request, 에러코드 $code") {
+                        mockMvc.delete("/api/v1/pages/{id}", id) {
+                            with(authentication(authentication))
+                            with(csrf())
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", Is.`is`(code))
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepositoryImplTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/page/repository/ProjectPageRepositoryImplTest.kt
@@ -1,102 +1,57 @@
 package com.wafflestudio.webgam.domain.page.repository
 
-import com.wafflestudio.webgam.domain.page.model.ProjectPage
-import com.wafflestudio.webgam.domain.project.model.Project
-import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
-import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.TestUtils.Companion.testData1
 import com.wafflestudio.webgam.domain.user.repository.UserRepository
 import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.Spec
-import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Tag
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
 
 @DataJpaTest
 @Import(TestQueryDslConfig::class)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
-@Tag("Repository-Test")
-@DisplayName("ProjectPageRepository Data JPA 테스트")
+@DisplayName("ProjectPageRepository 테스트")
 class ProjectPageRepositoryImplTest(
-    @Autowired private val userRepository: UserRepository,
-    @Autowired private val projectRepository: ProjectRepository,
-    @Autowired private val projectPageRepository: ProjectPageRepository,
-) : DescribeSpec() {
+    private val userRepository: UserRepository,
+    private val projectPageRepository: ProjectPageRepository,
+) : BehaviorSpec() {
 
-    private lateinit var projects: List<Project>
-    private lateinit var pageLists: List<List<ProjectPage>>
-
-    companion object {
-        val projectTitles = listOf("test-project-0", "test-project-1", "test-project-2", "deleted-project")
-        val pageNames = listOf("test-page-0", "test-page-1", "test-page-2", "deleted-page")
-    }
-
-    @Transactional
-    override suspend fun beforeSpec(spec: Spec) {
-        withContext(Dispatchers.IO) {
-            val user = userRepository.save(User("test-id", "test-username", "test@email.com", ""))
-            projects = projectTitles.map {
-                val project = Project(user, it)
-                if (it.contains("deleted")) project.delete()
-                projectRepository.save(project)
-            }
-            pageLists = projects.map { p -> pageNames.map {
-                val projectPage = ProjectPage(p, it)
-                if (it.contains("deleted")) projectPage.delete()
-                projectPageRepository.save(projectPage)
-            } }
-        }
-    }
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
 
     override suspend fun afterSpec(spec: Spec) {
         withContext(Dispatchers.IO) {
-            projectPageRepository.deleteAll()
-            projectRepository.deleteAll()
             userRepository.deleteAll()
         }
     }
 
     init {
-        this.describe("findUndeletedProjectPageById 호출될 때") {
-            context("성공적인 경우") {
-                val id = pageLists[0][0].id
+        this.Given("testData1") {
+            val data = testData1()
+            userRepository.saveAll(data)
 
-                it("삭제 되지 않은 ProjectPage가 반환된다") {
-                    val projectPage = projectPageRepository.findUndeletedProjectPageById(id)
+            val pages = data.map { u -> u.projects.map { it.pages }.flatten() }.flatten()
+            val maxId = projectPageRepository.findAll().maxOf { it.id }
 
-                    projectPage shouldNotBe null
-                    projectPage!!.isDeleted shouldBe false
+            When("findUndeletedProjectPageById 호출하면") {
+                for (page in pages) {
+                    val foundPage = projectPageRepository.findUndeletedProjectPageById(page.id)
+                    if (!page.isDeleted) {
+                        Then("삭제 되지 않은 페이지 객체를 반환한다: ${page.name}") { foundPage shouldBe page }
+                    } else {
+                        Then("삭제 되었으면 NULL을 반환한다: ${page.name}") { foundPage shouldBe null }
+                    }
                 }
-            }
 
-            context("해당 id를 갖는 ProjectPage가 없는 경우") {
-                val id = pageLists[0][0].id + 1000
-
-                it("NULL이 반환된다") {
-                    val projectPage = projectPageRepository.findUndeletedProjectPageById(id)
-
-                    projectPage shouldBe  null
-                }
-            }
-
-            context("해당 id를 갖는 ProjectPage가 삭제된 경우") {
-                val id = pageLists[0].find { it.isDeleted }!!.id
-
-                it("NULL이 반환된다") {
-                    val projectPage = projectPageRepository.findUndeletedProjectPageById(id)
-
-                    projectPage shouldBe  null
-                }
+                val foundPage = projectPageRepository.findUndeletedProjectPageById(maxId + 1)
+                Then("존재하지 않는 경우에도 NULL을 반환한다") { foundPage shouldBe null }
             }
         }
     }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageServiceTest.kt
@@ -1,4 +1,151 @@
 package com.wafflestudio.webgam.domain.page.service
 
-class ProjectPageServiceTest {
+import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.*
+import com.wafflestudio.webgam.domain.page.exception.NonAccessibleProjectPageException
+import com.wafflestudio.webgam.domain.page.exception.ProjectPageNotFoundException
+import com.wafflestudio.webgam.domain.page.model.ProjectPage
+import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.project.exception.NonAccessibleProjectException
+import com.wafflestudio.webgam.domain.project.exception.ProjectNotFoundException
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+@DisplayName("ProjectPageService 단위 테스트")
+class ProjectPageServiceTest: DescribeSpec() {
+    companion object {
+        private val projectPageRepository = mockk<ProjectPageRepository>()
+        private val projectRepository = mockk<ProjectRepository>()
+        private val projectPageService = ProjectPageService(projectPageRepository, projectRepository)
+        private val project = mockk<Project>()
+        private val nonAccessibleProject = mockk<Project>()
+        private val page = ProjectPage(project, "test-page")
+        private val nonAccessiblePage = mockk<ProjectPage>()
+
+        private const val USER_ID = 1L
+        private const val NORMAL = 1L
+        private const val DELETED = 2L
+        private const val NON_ACCESSIBLE = 3L
+    }
+
+    override suspend fun beforeSpec(spec: Spec) {
+        every { projectRepository.findUndeletedProjectById(NORMAL) } returns project
+        every { projectRepository.findUndeletedProjectById(DELETED) } returns null
+        every { projectRepository.findUndeletedProjectById(NON_ACCESSIBLE) } returns nonAccessibleProject
+
+        every { projectPageRepository.findUndeletedProjectPageById(NORMAL) } returns page
+        every { projectPageRepository.findUndeletedProjectPageById(DELETED) } returns null
+        every { projectPageRepository.findUndeletedProjectPageById(NON_ACCESSIBLE) } returns nonAccessiblePage
+
+        every { projectPageRepository.save(any()) } returns page
+
+        every { nonAccessibleProject.isAccessibleTo(any()) } returns false
+        every { nonAccessiblePage.isAccessibleTo(any()) } returns false
+
+        every { project.isAccessibleTo(USER_ID) } returns true
+        every { project.id } returns NORMAL
+        every { project.pages } returns mutableListOf()
+    }
+
+    init {
+        this.describe("getProjectPage 호출될 때") {
+            context("정상적인 경우") {
+                it("페이지가 DetailedResponse로 반환된다") {
+                    val response = shouldNotThrowAny { projectPageService.getProjectPage(USER_ID, NORMAL) }
+                    response shouldBe DetailedResponse(page)
+                }
+            }
+
+            context("페이지가 삭제되거나 없는 경우") {
+                it("ProjectPageNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectPageNotFoundException> { projectPageService.getProjectPage(USER_ID, DELETED) }
+                }
+            }
+
+            context("페이지에 접근 못하는 경우") {
+                it("NonAccessibleProjectPageException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectPageException> { projectPageService.getProjectPage(USER_ID, NON_ACCESSIBLE) }
+                }
+            }
+        }
+
+        this.describe("createProjectPage 호출될 때") {
+            context("정상적인 경우") {
+                val request = CreateRequest(NORMAL, "test-page")
+
+                it("페이지가 DetailedResponse로 반환된다") {
+                    val response = shouldNotThrowAny { projectPageService.createProjectPage(USER_ID, request) }
+                    response shouldBe DetailedResponse(page)
+                }
+            }
+
+            context("프로젝트가 삭제되거나 없는 경우") {
+                val request = CreateRequest(DELETED, "test-page")
+
+                it("ProjectNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectNotFoundException> { projectPageService.createProjectPage(USER_ID, request) }
+                }
+            }
+
+            context("프로젝트에 접근 못하는 경우") {
+                val request = CreateRequest(NON_ACCESSIBLE, "test-page")
+
+                it("NonAccessibleProjectException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectException> { projectPageService.createProjectPage(USER_ID, request) }
+                }
+            }
+        }
+
+        this.describe("patchProjectPage 호출될 때") {
+            val request = PatchRequest("test-page-patch")
+
+            context("정상적인 경우") {
+                it("페이지가 DetailedResponse로 반환된다") {
+                    val response = shouldNotThrowAny { projectPageService.patchProjectPage(USER_ID, NORMAL, request) }
+                    response shouldBe DetailedResponse(page)
+                }
+            }
+
+            context("페이지가 삭제되거나 없는 경우") {
+                it("ProjectPageNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectPageNotFoundException> { projectPageService.patchProjectPage(USER_ID, DELETED, request) }
+                }
+            }
+
+            context("페이지에 접근 못하는 경우") {
+                it("NonAccessibleProjectPageException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectPageException> { projectPageService.patchProjectPage(USER_ID, NON_ACCESSIBLE, request) }
+                }
+            }
+        }
+
+        this.describe("deleteProjectPage 호출될 때") {
+            context("정상적인 경우") {
+                it("아무런 예외도 발생하지 않으며 리턴 값도 없다") {
+                    val ret = shouldNotThrowAny { projectPageService.deleteProjectPage(USER_ID, NORMAL) }
+                    ret shouldBe Unit
+                }
+            }
+
+            context("페이지가 삭제되거나 없는 경우") {
+                it("ProjectPageNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectPageNotFoundException> { projectPageService.deleteProjectPage(USER_ID, DELETED) }
+                }
+            }
+
+            context("페이지에 접근 못하는 경우") {
+                it("NonAccessibleProjectPageException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectPageException> { projectPageService.deleteProjectPage(USER_ID, NON_ACCESSIBLE) }
+                }
+            }
+        }
+    }
+
 }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageServiceTestWithRepository.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/page/service/ProjectPageServiceTestWithRepository.kt
@@ -1,0 +1,176 @@
+package com.wafflestudio.webgam.domain.page.service
+
+import com.wafflestudio.webgam.TestUtils.Companion.testData1
+import com.wafflestudio.webgam.domain.event.repository.ObjectEventRepository
+import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
+import com.wafflestudio.webgam.domain.page.dto.ProjectPageDto.*
+import com.wafflestudio.webgam.domain.page.exception.NonAccessibleProjectPageException
+import com.wafflestudio.webgam.domain.page.exception.ProjectPageNotFoundException
+import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@Import(TestQueryDslConfig::class)
+@ActiveProfiles("test")
+@DisplayName("ProjectPage Service-Repository 테스트")
+class ProjectPageServiceTestWithRepository(
+    private val userRepository: UserRepository,
+    projectRepository: ProjectRepository,
+    private val projectPageRepository: ProjectPageRepository,
+    private val pageObjectRepository: PageObjectRepository,
+    private val objectEventRepository: ObjectEventRepository,
+): BehaviorSpec() {
+
+    private val projectPageService = ProjectPageService(projectPageRepository, projectRepository)
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    override suspend fun afterSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            userRepository.deleteAll()
+        }
+    }
+
+    init {
+        this.Given("testData1") {
+            val data = testData1()
+            userRepository.saveAll(data)
+
+            data.filter { !it.isDeleted }.forEach { user ->
+                val normalUserPages = user.projects.map { it.pages }.flatten().filter { !it.isDeleted }
+                val deletedUserPages = user.projects.map { it.pages }.flatten().filter { it.isDeleted }
+                val nonAccessiblePages = data.filter { it.id != user.id }.map { u -> u.projects.map { it.pages }
+                    .flatten() }.flatten().filter { !it.isDeleted }
+
+                normalUserPages.forEach { page ->
+                    When("일반적으로 유저 ID와 페이지 ID로 페이지 조회하면: ${user.username} ${page.name}") {
+                        val foundPage = projectPageRepository.findUndeletedProjectPageById(page.id)
+                        val response = shouldNotThrowAny { projectPageService.getProjectPage(user.id, page.id) }
+                        Then("저장된 페이지가 조회된다") {
+                            foundPage shouldBe page
+                            response shouldBe DetailedResponse(page)
+                        }
+                    }
+                }
+
+                deletedUserPages.forEach { page ->
+                    When("삭제된 페이지에 접근하면: ${user.username} ${page.name}") {
+                        Then("ProjectPageNotFoundException 예외가 발생한다") {
+                            shouldThrow<ProjectPageNotFoundException> {
+                                projectPageService.getProjectPage(user.id, page.id)
+                            }
+                            shouldThrow<ProjectPageNotFoundException> {
+                                projectPageService.patchProjectPage(user.id, page.id, PatchRequest("patch"))
+                            }
+                            shouldThrow<ProjectPageNotFoundException> {
+                                projectPageService.deleteProjectPage(user.id, page.id)
+                            }
+                        }
+                    }
+                }
+
+                nonAccessiblePages.forEach { page ->
+                    When("접근권한이 없는 페이지에 접근하면: ${user.username} ${page.name}") {
+                        Then("NonAccessibleProjectPageException 예외가 발생한다") {
+                            shouldThrow<NonAccessibleProjectPageException> {
+                                projectPageService.getProjectPage(user.id, page.id)
+                            }
+                            shouldThrow<NonAccessibleProjectPageException> {
+                                projectPageService.patchProjectPage(user.id, page.id, PatchRequest("patch"))
+                            }
+                            shouldThrow<NonAccessibleProjectPageException> {
+                                projectPageService.deleteProjectPage(user.id, page.id)
+                            }
+                        }
+                    }
+                }
+            }
+
+            When("새로운 페이지를 생성하면") {
+                val user = data.first { it.username == "user-01" }
+                val project = user.projects.first { it.title == "project-01" }
+                val request = CreateRequest(project.id, "new-page")
+                val response = shouldNotThrowAny { projectPageService.createProjectPage(user.id, request) }
+                val foundPage = projectPageRepository.findByIdOrNull(response.id)!!
+
+                Then("정상적으로 DB에 저장된다") {
+                    response shouldBe DetailedResponse(foundPage)
+                    response.projectId shouldBe project.id
+                    response.name shouldBe request.name
+                }
+
+                Then("성공적으로 연관관계 매핑이 이루어진다") {
+                    project.pages shouldContain foundPage
+                }
+            }
+
+            When("페이지를 수정하면") {
+                val user = data.first { it.username == "user-01" }
+                val project = user.projects.first { it.title == "project-01" }
+                val page = project.pages.first { it.name == "page-02" }
+                val request = PatchRequest("modified-page")
+                val response = shouldNotThrowAny { projectPageService.patchProjectPage(user.id, page.id, request) }
+                val foundPage = projectPageRepository.findByIdOrNull(page.id)!!
+
+                Then("정상적으로 DB에 반영된다") {
+                    foundPage shouldBe page
+                    response shouldBe DetailedResponse(foundPage)
+                    response.name shouldBe request.name
+                }
+            }
+
+            When("페이지를 삭제하면") {
+                val user = data.first { it.username == "user-01" }
+                val project = user.projects.first { it.title == "project-01" }
+                val page = project.pages.first { it.name == "page-02" }
+                shouldNotThrowAny { projectPageService.deleteProjectPage(user.id, page.id) }
+                val foundPage = projectPageRepository.findByIdOrNull(page.id)!!
+
+                Then("정상적으로 DB에 반영된다") {
+                    foundPage shouldBe page
+                    foundPage.isDeleted shouldBe true
+                }
+
+                Then("페이지 조회, 수정, 삭제가 더 이상 불가능하다") {
+                    shouldThrow<ProjectPageNotFoundException> { projectPageService.getProjectPage(user.id, page.id) }
+                    shouldThrow<ProjectPageNotFoundException> { projectPageService.patchProjectPage(user.id, page.id, PatchRequest("patch")) }
+                    shouldThrow<ProjectPageNotFoundException> { projectPageService.deleteProjectPage(user.id, page.id) }
+                }
+
+                Then("하위 오브젝트, 이벤트들도 삭제된다") {
+                    page.objects.forEach { pageObject ->
+                        val foundObject = pageObjectRepository.findByIdOrNull(pageObject.id)!!
+
+                        foundObject shouldBe pageObject
+                        foundObject.isDeleted shouldBe true
+
+                        pageObject.events.forEach { event ->
+                            val foundEvent = objectEventRepository.findByIdOrNull(event.id)!!
+
+                            foundEvent shouldBe event
+                            foundEvent.isDeleted shouldBe true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/project/ProjectDescribeSpec.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/project/ProjectDescribeSpec.kt
@@ -2,16 +2,12 @@ package com.wafflestudio.webgam.domain.project
 
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.GsonBuilder
-import com.wafflestudio.webgam.RestDocsUtils.Companion.requestBody
-import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentResponse
 import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentRequest
+import com.wafflestudio.webgam.RestDocsUtils.Companion.getDocumentResponse
+import com.wafflestudio.webgam.RestDocsUtils.Companion.requestBody
 import com.wafflestudio.webgam.STRING
-import com.wafflestudio.webgam.domain.project.dto.ProjectDto
-import com.wafflestudio.webgam.domain.project.model.Project
-import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
-import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.TestUtils
 import com.wafflestudio.webgam.domain.user.repository.UserRepository
-import com.wafflestudio.webgam.global.common.exception.ErrorType
 import com.wafflestudio.webgam.global.security.model.UserPrincipal
 import com.wafflestudio.webgam.global.security.model.WebgamAuthenticationToken
 import com.wafflestudio.webgam.type
@@ -21,146 +17,72 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.hamcrest.core.Is
-import org.junit.jupiter.api.Tag
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete
-import org.springframework.restdocs.request.RequestDocumentation.pathParameters
-import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
-import org.springframework.restdocs.request.RequestDocumentation.queryParameters
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*
+import org.springframework.restdocs.request.RequestDocumentation.*
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @ActiveProfiles("test")
-@Tag("Integration-Test")
 @DisplayName("Project 통합 테스트")
 class ProjectDescribeSpec (
-        @Autowired private val mockMvc: MockMvc,
-        @Autowired private val userRepository: UserRepository,
-        @Autowired private val projectRepository: ProjectRepository,
+    private val mockMvc: MockMvc,
+    private val userRepository: UserRepository,
 ): DescribeSpec(){
 
     override fun extensions() = listOf(SpringExtension)
 
-    final val user = userRepository.save(User("fooId", "foo", "foo@wafflestudio.com", ""))
-    private final val dummyUser = userRepository.save(User("barId", "bar", "bar@wafflestudio.com", ""))
-    private final val auth = WebgamAuthenticationToken(UserPrincipal(user), "")
-    private final val defaultProject = projectRepository.save(Project(user, "default-project"))
-    private final val dummyProject = projectRepository.save(Project(dummyUser, "dummy-project"))
-
-    private lateinit var deletedProject: Project
-
-
     override suspend fun beforeSpec(spec: Spec) {
-        val p = Project(user, "deleted-project")
-        p.isDeleted = true
-
-        withContext(Dispatchers.IO) {
-            deletedProject = projectRepository.save(p)
-        }
+        userRepository.saveAll(data)
     }
 
     override suspend fun afterSpec(spec: Spec) {
         withContext(Dispatchers.IO) {
-            projectRepository.deleteAll()
             userRepository.deleteAll()
         }
     }
 
     companion object {
         private val gson = GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
-        private val validCreateRequest = ProjectDto.CreateRequest("new_title")
-        private val validPatchRequest = ProjectDto.PatchRequest("title_changed")
+        private val data = TestUtils.docTestData()
+        private val auth = WebgamAuthenticationToken(UserPrincipal(data.first()), "")
+        private val project = data.first().projects.first()
     }
 
     init {
         this.describe("프로젝트 조회할 때") {
             context("성공하면") {
                 it("200 OK") {
-                    mockMvc.perform(get("/api/v1/project/{id}", defaultProject.id.toString())
+                    mockMvc.perform(get("/api/v1/projects/{id}", project.id)
                             .with(authentication(auth))
                     ).andDo(document(
-                            "get-project/200",
+                            "project/get",
                             getDocumentRequest(),
                             getDocumentResponse(),
                             pathParameters(parameterWithName("id").description("프로젝트 ID")),
                     )).andExpect(status().isOk).andDo(print())
                 }
             }
-
-            context("올바르지 않은 프로젝트 ID일 때") {
-                val errorCode = ErrorType.BadRequest.CONSTRAINT_VIOLATION.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            get("/api/v1/project/{id}", "0")
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "get-project/400-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트에 접근하지 못하는 경우") {
-                val errorCode = ErrorType.Forbidden.NON_ACCESSIBLE_PROJECT.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            get("/api/v1/project/{id}", dummyProject.id.toString())
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "get-project/403-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트가 없거나 삭제 되었을 때") {
-                val errorCode = ErrorType.NotFound.PROJECT_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            get("/api/v1/project/{id}", deletedProject.id.toString())
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "get-project/404-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
         }
 
         this.describe("모든 프로젝트 조회"){
             context("성공하면"){
                 it("200 OK") {
-                    mockMvc.perform(get("/api/v1/project")
+                    mockMvc.perform(get("/api/v1/projects")
                             .param("page","0")
                             .param("size","10")
                     ).andDo(document(
-                            "get-projects/200",
+                            "project/get-list",
                             getDocumentRequest(),
                             getDocumentResponse(),
                             queryParameters(parameterWithName("page").description("페이지 번호"),
@@ -173,10 +95,10 @@ class ProjectDescribeSpec (
         this.describe("나의 모든 프로젝트 조회"){
             context("성공하면"){
                 it("200 OK"){
-                    mockMvc.perform(get("/api/v1/project/me")
+                    mockMvc.perform(get("/api/v1/projects/me")
                             .with(authentication(auth))
                     ).andDo(document(
-                            "get-my-projects/200",
+                            "project/get-user-list",
                             getDocumentRequest(),
                             getDocumentResponse(),
                     )).andExpect(status().isOk).andDo(print())
@@ -186,13 +108,15 @@ class ProjectDescribeSpec (
 
         this.describe("프로젝트 생성할 때") {
             context("성공하면") {
+                val request = mapOf("title" to "create-project")
+
                 it("200 OK") {
-                    mockMvc.perform(post("/api/v1/project")
+                    mockMvc.perform(post("/api/v1/projects")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(gson.toJson(validCreateRequest))
+                            .content(gson.toJson(request))
                             .with(authentication(auth))
                     ).andDo(document(
-                            "create-project/200",
+                            "project/create",
                             getDocumentRequest(),
                             getDocumentResponse(),
                             requestBody(
@@ -201,38 +125,19 @@ class ProjectDescribeSpec (
                     )).andExpect(status().isOk).andDo(print())
                 }
             }
-
-            context("올바르지 않은 값을 넣거나 필수값이 없을 때") {
-                val request = mapOf("title" to "   ")
-
-                val errorCode = ErrorType.BadRequest.INVALID_FIELD.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            post("/api/v1/project")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(request))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "create-project/400-0",
-                            getDocumentResponse(),
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
         }
 
         this.describe("프로젝트 수정할 때") {
             context("성공하면") {
+                val request = mapOf("title" to "patch-project")
 
                 it("200 OK") {
-                    mockMvc.perform(patch("/api/v1/project/{id}", defaultProject.id.toString())
+                    mockMvc.perform(patch("/api/v1/projects/{id}", project.id)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(gson.toJson(validPatchRequest))
+                            .content(gson.toJson(request))
                             .with(authentication(auth))
                     ).andDo(document(
-                            "patch-project/200",
+                            "project/patch",
                             getDocumentRequest(),
                             getDocumentResponse(),
                             pathParameters(parameterWithName("id").description("프로젝트 ID")),
@@ -240,80 +145,6 @@ class ProjectDescribeSpec (
                                     "title" type STRING means "제목",
                             )
                     )).andExpect(status().isOk).andDo(print())
-                }
-            }
-
-            context("올바르지 않은 값을 넣을 때") {
-                val request = mapOf("title" to "   ")
-
-                val errorCode = ErrorType.BadRequest.INVALID_FIELD.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            patch("/api/v1/project/{id}", defaultProject.id.toString())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(request))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "patch-project/400-0",
-                            getDocumentResponse(),
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("올바르지 않은 프로젝트 ID일 때") {
-                val errorCode = ErrorType.BadRequest.CONSTRAINT_VIOLATION.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            patch("/api/v1/project/{id}", "0")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(validPatchRequest))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "patch-project/400-1",
-                            getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트에 접근하지 못하는 경우") {
-                val errorCode = ErrorType.Forbidden.NON_ACCESSIBLE_PROJECT.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            patch("/api/v1/project/{id}", dummyProject.id.toString())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(validPatchRequest))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "patch-project/403-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트가 없거나 삭제 되었을 때") {
-                val errorCode = ErrorType.NotFound.PROJECT_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            patch("/api/v1/project/{id}", deletedProject.id.toString())
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(gson.toJson(validPatchRequest))
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "patch-project/404-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
                 }
             }
         }
@@ -322,67 +153,16 @@ class ProjectDescribeSpec (
             context("성공하면") {
                 it("200 OK") {
                     mockMvc.perform(
-                            delete("/api/v1/project/{id}", defaultProject.id.toString())
+                            delete("/api/v1/projects/{id}", project.id)
                                     .with(authentication(auth))
                     ).andDo(document(
-                            "delete-project/200",
+                            "project/delete",
                             getDocumentRequest(),
                             getDocumentResponse(),
                             pathParameters(parameterWithName("id").description("프로젝트 ID")),
                     )).andExpect(status().isOk).andDo(print())
                 }
             }
-
-            context("올바르지 않은 프로젝트 ID일 때") {
-                val errorCode = ErrorType.BadRequest.CONSTRAINT_VIOLATION.code()
-
-                it("400 Bad Request, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            delete("/api/v1/project/{id}", "0")
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "delete-project/400-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isBadRequest
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트에 접근하지 못하는 경우") {
-                val errorCode = ErrorType.Forbidden.NON_ACCESSIBLE_PROJECT.code()
-
-                it("403 Forbidden, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            delete("/api/v1/project/{id}", dummyProject.id.toString())
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "delete-project/403-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isForbidden
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
-            context("해당 ID를 갖는 프로젝트가 없거나 삭제 되었을 때") {
-                val errorCode = ErrorType.NotFound.PROJECT_NOT_FOUND.code()
-
-                it("404 Not Found, 에러코드 $errorCode") {
-                    mockMvc.perform(
-                            delete("/api/v1/project/{id}", deletedProject.id.toString())
-                                    .with(authentication(auth))
-                    ).andDo(document(
-                            "delete-project/404-0",
-                            getDocumentResponse()
-                    )).andExpect(status().isNotFound
-                    ).andExpect(jsonPath("$.error_code", Is.`is`(errorCode))
-                    ).andDo(print())
-                }
-            }
-
         }
-
     }
-
 }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/project/controller/ProjectControllerTest.kt
@@ -1,5 +1,245 @@
 package com.wafflestudio.webgam.domain.project.controller
 
-class ProjectControllerTest(){
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.webgam.TestUtils
+import com.wafflestudio.webgam.TestUtils.Companion.pathVariableIds
+import com.wafflestudio.webgam.domain.project.dto.ProjectDto.DetailedResponse
+import com.wafflestudio.webgam.domain.project.dto.ProjectDto.SimpleResponse
+import com.wafflestudio.webgam.domain.project.service.ProjectService
+import com.wafflestudio.webgam.global.common.exception.ErrorType
+import com.wafflestudio.webgam.global.security.model.UserPrincipal
+import com.wafflestudio.webgam.global.security.model.WebgamAuthenticationToken
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.mockk.every
+import io.mockk.justRun
+import org.hamcrest.core.Is
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.*
 
+@WebMvcTest(ProjectController::class)
+@MockkBean(JpaMetamodelMappingContext::class)
+@ActiveProfiles("test")
+@DisplayName("ProjectController 테스트")
+class ProjectControllerTest(
+    private val mockMvc: MockMvc,
+    @MockkBean private val projectService: ProjectService,
+): DescribeSpec() {
+
+    companion object {
+        private val gson = GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create()
+        private val user = TestUtils.testData1().first()
+        private val authentication = WebgamAuthenticationToken(UserPrincipal(user), "")
+        private val project = user.projects.first()
+
+        /* Test Parameters */
+        private val ids = pathVariableIds()
+    }
+
+    override suspend fun beforeSpec(spec: Spec) {
+        every { projectService.getProjectList(any(), any()) } returns SliceImpl(listOf(SimpleResponse(project)))
+        every { projectService.createProject(any(), any()) } returns DetailedResponse(project)
+        every { projectService.getProject(any(), any()) } returns DetailedResponse(project)
+        every { projectService.patchProject(any(), any(), any()) } returns DetailedResponse(project)
+        justRun { projectService.deleteProject(any(), any()) }
+    }
+
+    init {
+        this.describe("프로젝트 생성할 때") {
+            val titles = listOf(
+                listOf("valid-project-title").map { it to null },
+                listOf(null, "", "   ").map { it to ErrorType.BadRequest.INVALID_FIELD.code() }).flatten()
+
+            val combinations = TestUtils.makeFieldList(titles)
+
+            val fields = listOf("title")
+
+            combinations.forAll { (l, t) ->
+                val (idx, code) = t
+                val request = l.mapIndexed { index, field -> fields[index] to field }.toMap()
+
+                when (idx) {
+                    -1 -> { context("Body의 모든 field가 올바르면") {
+                        it("200 OK") {
+                            mockMvc.post("/api/v1/projects") {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect { status { isOk() } }
+                        }
+                    } }
+                    else -> { context("${fields[idx]}가 올바르지 않은 값 '${l[idx]}' 이면") {
+                        it ("400 Bad Request, 에러코드 $code") {
+                            mockMvc.post("/api/v1/projects") {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect {
+                                status { isBadRequest() }
+                                jsonPath("$.error_code", Is.`is`(code))
+                            }
+                        }
+                    } }
+                }
+            }
+
+        }
+
+        this.describe("특정 프로젝트 조회할 때") {
+            val ids = TestUtils.makeFieldList(ids)
+
+            ids.forAll { (i, t) ->
+                val (idx, code) = t
+                val id = i[0].toString()
+
+                if (idx == -1) context("ID가 올바른 값 '${id}'이면") {
+                    it("200 OK") {
+                        mockMvc.get("/api/v1/projects/{id}", id) {
+                            param("project-id", id)
+                            with(authentication(authentication))
+                        }.andExpect { status { isOk() } }
+                    }
+                }
+                else context("ID가 올바르지 않은 값 '${id}'이면") {
+                    it("400 Bad Request, 에러코드 $code") {
+                        mockMvc.get("/api/v1/projects/{id}", id) {
+                            param("project-id", id)
+                            with(authentication(authentication))
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", Is.`is`(code))
+                        }
+                    }
+                }
+            }
+        }
+
+        this.describe("특정 프로젝트 수정할 때") {
+            val titles = listOf(
+                listOf("valid-page-name").map { it to null },
+                listOf(null, "", "   ").map { it to ErrorType.BadRequest.INVALID_FIELD.code() }).flatten()
+
+            val combinations = TestUtils.makeFieldList(ids, titles)
+
+            val fields = listOf("id", "title")
+
+            combinations.forAll { (l, t) ->
+                val (idx, code) = t
+                val request = mapOf(
+                    "title" to l[1]
+                )
+
+                when (idx) {
+                    -1 -> { context("Body의 모든 field가 올바르면") {
+                        it("200 OK") {
+                            mockMvc.patch("/api/v1/projects/{id}", l[0]) {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect { status { isOk() } }
+                        }
+                    } }
+                    else -> { context("${fields[idx]}가 올바르지 않은 값 '${l[idx]}' 이면") {
+                        it ("400 Bad Request, 에러코드 $code") {
+                            mockMvc.patch("/api/v1/projects/{id}", l[0]) {
+                                contentType = MediaType.APPLICATION_JSON
+                                content = gson.toJson(request)
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect {
+                                status { isBadRequest() }
+                                jsonPath("$.error_code", Is.`is`(code))
+                            }
+                        }
+                    } }
+                }
+            }
+        }
+
+        this.describe("특정 프로젝트 삭제할 때") {
+            val ids = TestUtils.makeFieldList(ids)
+
+            ids.forAll { (i, t) ->
+                val (idx, code) = t
+                val id = i[0].toString()
+
+                if (idx == -1) context("ID가 올바른 값 '${id}'이면") {
+                    it("200 OK") {
+                        mockMvc.delete("/api/v1/projects/{id}", id) {
+                            with(authentication(authentication))
+                            with(csrf())
+                        }.andExpect { status { isOk() } }
+                    }
+                }
+                else context("ID가 올바르지 않은 값 '${id}'이면") {
+                    it("400 Bad Request, 에러코드 $code") {
+                        mockMvc.delete("/api/v1/projects/{id}", id) {
+                            with(authentication(authentication))
+                            with(csrf())
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.error_code", Is.`is`(code))
+                        }
+                    }
+                }
+            }
+        }
+
+        this.describe("모든 프로젝트 목록 조회할 때") {
+            val pages = listOf(
+                listOf(0, 1, 3, 4, 10, null).map { it to null },
+                listOf(-1).map { it to ErrorType.BadRequest.CONSTRAINT_VIOLATION.code() },
+                listOf("nonInt").map { it to ErrorType.BadRequest.PARAMETER_TYPE_MISMATCH.code() }).flatten()
+            val sizes = listOf(
+                listOf(1, 3, 4, 10, null).map { it to null },
+                listOf(-1, 0).map { it to ErrorType.BadRequest.CONSTRAINT_VIOLATION.code() },
+                listOf("nonInt").map { it to ErrorType.BadRequest.PARAMETER_TYPE_MISMATCH.code() }).flatten()
+
+            val combinations = TestUtils.makeFieldList(pages, sizes)
+
+            val fields = listOf("page", "size")
+
+            combinations.forAll { (l, t) ->
+                val (idx, code) = t
+
+                when (idx) {
+                    -1 -> { context("모든 query parameter가 올바르면") {
+                        it("200 OK") {
+                            mockMvc.get("/api/v1/projects") {
+                                l[0] ?.let { param("page", l[0].toString()) }
+                                l[1] ?.let { param("size", l[1].toString()) }
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect { status { isOk() } }
+                        }
+                    } }
+                    else -> { context("${fields[idx]}가 올바르지 않은 값 '${l[idx]}' 이면") {
+                        it ("400 Bad Request, 에러코드 $code") {
+                            mockMvc.get("/api/v1/projects") {
+                                l[0] ?.let { param("page", l[0].toString()) }
+                                l[1] ?.let { param("size", l[1].toString()) }
+                                with(authentication(authentication))
+                                with(csrf())
+                            }.andExpect {
+                                status { isBadRequest() }
+                                jsonPath("$.error_code", Is.`is`(code))
+                            }
+                        }
+                    } }
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryImplTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/project/repository/ProjectRepositoryImplTest.kt
@@ -1,90 +1,78 @@
 package com.wafflestudio.webgam.domain.project.repository
 
-import com.wafflestudio.webgam.domain.project.model.Project
-import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.TestUtils.Companion.testData1
 import com.wafflestudio.webgam.domain.user.repository.UserRepository
 import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.Spec
-import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Tag
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageRequest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
 
 @DataJpaTest
 @Import(TestQueryDslConfig::class)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
-@Tag("Repository-Test")
-@DisplayName("ProjectRepository Data JPA 테스트")
+@DisplayName("ProjectRepository 테스트")
 class ProjectRepositoryImplTest(
-    @Autowired private val userRepository: UserRepository,
-    @Autowired private val projectRepository: ProjectRepository,
-) : DescribeSpec() {
-
-    private lateinit var projects: List<Project>
-
-    companion object {
-        val projectTitles = listOf("test-project-0", "test-project-1", "test-project-2", "deleted-project")
-    }
-
-    @Transactional
-    override suspend fun beforeSpec(spec: Spec) {
-        withContext(Dispatchers.IO) {
-            val user = userRepository.save(User("test-id", "test-username", "test@email.com", ""))
-            projects = projectTitles.map {
-                val project = Project(user, it)
-                if (it.contains("deleted")) project.delete()
-                projectRepository.save(project)
-            }
-        }
-    }
+    private val userRepository: UserRepository,
+    private val projectRepository: ProjectRepository,
+): BehaviorSpec() {
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
 
     override suspend fun afterSpec(spec: Spec) {
         withContext(Dispatchers.IO) {
-            projectRepository.deleteAll()
             userRepository.deleteAll()
         }
     }
 
     init {
-        this.describe("findUndeletedProjectById 호출될 때") {
-            context("성공적인 경우") {
-                val id = projects[0].id
+        this.Given("testData1") {
+            val data = testData1()
+            userRepository.saveAll(data)
 
-                it("삭제 되지 않은 Project가 반환된다") {
-                    val project = projectRepository.findUndeletedProjectById(id)
+            val projects = data.map { it.projects }.flatten()
+            val maxId = projectRepository.findAll().maxOf { it.id }
+            val maxUserId = userRepository.findAll().maxOf { it.id }
 
-                    project shouldNotBe null
-                    project!!.isDeleted shouldBe false
+            When("findUndeletedProjectById 호출하면") {
+                for (project in projects) {
+                    val foundProject = projectRepository.findUndeletedProjectById(project.id)
+                    if (!project.isDeleted) {
+                        Then("삭제 되지 않은 프로젝트 객체를 반환한다: ${project.title}") { foundProject shouldBe project }
+                    } else {
+                        Then("삭제 되었으면 NULL을 반환한다: ${project.title}") { foundProject shouldBe null }
+                    }
                 }
+
+                val foundProject = projectRepository.findUndeletedProjectById(maxId + 1)
+                Then("존재하지 않는 경우에도 NULL을 반환한다") { foundProject shouldBe null }
             }
 
-            context("해당 id를 갖는 Project가 없는 경우") {
-                val id = projects[0].id + 1000
-
-                it("NULL이 반환된다") {
-                    val project = projectRepository.findUndeletedProjectById(id)
-
-                    project shouldBe  null
+            When("findUndeletedAllByOwnerIdEquals 호출하면") {
+                for (user in data) {
+                    val foundProjects = projectRepository.findUndeletedAllByOwnerIdEquals(user.id)
+                    Then("유저의 삭제되지 않은 모든 프로젝트가 리스트로 반환된다: ${user.username}") {
+                        foundProjects shouldContainExactlyInAnyOrder user.projects.filter { !it.isDeleted }
+                    }
                 }
+
+                val foundProjects = projectRepository.findUndeletedAllByOwnerIdEquals(maxUserId + 1)
+                Then("해당 유저가 없는 경우에는 빈 리스트를 반환한다") { foundProjects.shouldBeEmpty() }
             }
 
-            context("해당 id를 갖는 Project가 삭제된 경우") {
-                val id = projects.find { it.isDeleted }!!.id
-
-                it("NULL이 반환된다") {
-                    val project = projectRepository.findUndeletedProjectById(id)
-
-                    project shouldBe  null
+            When("findUndeletedAll 호출하면") {
+                val foundProjects = projectRepository.findUndeletedAll(PageRequest.of(0, projects.size))
+                Then("삭제되지 않은 프로젝트가 리스트로 반환된다") {
+                    foundProjects.content shouldContainExactlyInAnyOrder projects.filter { !it.isDeleted }
                 }
             }
         }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/project/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/project/service/ProjectServiceTest.kt
@@ -1,4 +1,154 @@
 package com.wafflestudio.webgam.domain.project.service
 
-class ProjectServiceTest {
+import com.wafflestudio.webgam.domain.project.dto.ProjectDto.*
+import com.wafflestudio.webgam.domain.project.exception.NonAccessibleProjectException
+import com.wafflestudio.webgam.domain.project.exception.ProjectNotFoundException
+import com.wafflestudio.webgam.domain.project.model.Project
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import com.wafflestudio.webgam.domain.user.model.User
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+
+@DisplayName("ProjectService 단위 테스트")
+class ProjectServiceTest: DescribeSpec() {
+
+    companion object {
+        private val projectRepository = mockk<ProjectRepository>()
+        private val userRepository = mockk<UserRepository>()
+        private val projectService = ProjectService(projectRepository, userRepository)
+        private val user = mockk<User>()
+        private val project = Project(user, "project")
+        private val nonAccessibleProject = mockk<Project>()
+
+        private const val USER_ID = 1L
+        private const val NORMAL = 1L
+        private const val DELETED = 2L
+        private const val NON_ACCESSIBLE = 3L
+    }
+
+    override suspend fun beforeSpec(spec: Spec) {
+        every { projectRepository.save(any()) } returns project
+        every { projectRepository.findUndeletedProjectById(NORMAL) } returns project
+        every { projectRepository.findUndeletedProjectById(DELETED) } returns null
+        every { projectRepository.findUndeletedProjectById(NON_ACCESSIBLE) } returns nonAccessibleProject
+        every { projectRepository.findUndeletedAll(any<PageRequest>()) } returns SliceImpl(listOf(project))
+        every { projectRepository.findUndeletedAllByOwnerIdEquals(USER_ID) } returns listOf(project)
+
+        every { userRepository.findUserById(USER_ID) } returns user
+
+        every { user.id } returns USER_ID
+        every { user.userId } returns "user-id"
+        every { user.username } returns "username"
+        every { user.email } returns "user@email.com"
+        every { user.projects } returns mutableListOf()
+
+        every { nonAccessibleProject.isAccessibleTo(USER_ID) } returns false
+    }
+
+    init {
+        this.describe("getProject 호출될 때") {
+            context("정상적인 경우") {
+                it("프로젝트가 DetailedResponse로 반환된다") {
+                    val response = shouldNotThrowAny { projectService.getProject(USER_ID, NORMAL) }
+                    response shouldBe DetailedResponse(project)
+                }
+            }
+
+            context("프로젝트가 삭제되거나 없는 경우") {
+                it("ProjectNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectNotFoundException> { projectService.getProject(USER_ID, DELETED) }
+                }
+            }
+
+            context("프로젝트에 접근 권한이 없는 경우") {
+                it("NonAccessibleProjectException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectException> { projectService.getProject(USER_ID, NON_ACCESSIBLE) }
+                }
+            }
+        }
+
+        this.describe("getProjectList 호출될 때") {
+            context("정상적인 경우") {
+                it("모든 프로젝트가 SimpleResponse의 형태로 PageResponse에 담겨 반환된다") {
+                    val response = shouldNotThrowAny { projectService.getProjectList(0, 10) }
+                    response.content shouldContain SimpleResponse(project)
+                }
+            }
+        }
+
+        this.describe("getUserProject 호출될 때") {
+            context("정상적인 경우") {
+                it("유저의 프로젝트 목록이 SimpleResponse의 형태로 ListResponse에 담겨 반환된다") {
+                    val response = shouldNotThrowAny { projectService.getUserProject(USER_ID) }
+                    response.data shouldContain SimpleResponse(project)
+                }
+            }
+        }
+
+        this.describe("createProject 호출될 때") {
+            val request = CreateRequest("create-project")
+
+            context("정상적인 경우") {
+                it("프로젝트가 DetailedResponse로 반환된다") {
+                    val response = shouldNotThrowAny { projectService.createProject(USER_ID, request) }
+                    response shouldBe DetailedResponse(project)
+                }
+            }
+        }
+
+        this.describe("patchProject 호출될 때") {
+            val request = PatchRequest("patch-project")
+
+            context("정상적인 경우") {
+                it("프로젝트가 DetailedResponse로 반환된다") {
+                    val response = shouldNotThrowAny { projectService.patchProject(USER_ID, NORMAL, request) }
+                    response shouldBe DetailedResponse(project)
+                }
+            }
+
+            context("프로젝트가 삭제되거나 없는 경우") {
+                it("ProjectNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectNotFoundException> { projectService.patchProject(USER_ID, DELETED, request) }
+                }
+            }
+
+            context("프로젝트에 접근 권한이 없는 경우") {
+                it("NonAccessibleProjectException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectException> { projectService.patchProject(USER_ID, NON_ACCESSIBLE, request) }
+                }
+            }
+        }
+
+        this.describe("deleteProject 호출될 때") {
+            context("정상적인 경우") {
+                it("아무런 예외도 발생하지 않으며 리턴 값도 없다") {
+                    val ret = shouldNotThrowAny { projectService.deleteProject(USER_ID, NORMAL) }
+                    ret shouldBe Unit
+                }
+            }
+
+            context("프로젝트가 삭제되거나 없는 경우") {
+                it("ProjectNotFoundException 예외를 던진다") {
+                    shouldThrow<ProjectNotFoundException> { projectService.deleteProject(USER_ID, DELETED) }
+                }
+            }
+
+            context("프로젝트에 접근 권한이 없는 경우") {
+                it("NonAccessibleProjectException 예외를 던진다") {
+                    shouldThrow<NonAccessibleProjectException> { projectService.deleteProject(USER_ID, NON_ACCESSIBLE) }
+                }
+            }
+        }
+    }
+
 }

--- a/src/test/kotlin/com/wafflestudio/webgam/domain/project/service/ProjectServiceTestWithRepository.kt
+++ b/src/test/kotlin/com/wafflestudio/webgam/domain/project/service/ProjectServiceTestWithRepository.kt
@@ -1,0 +1,224 @@
+package com.wafflestudio.webgam.domain.project.service
+
+import com.wafflestudio.webgam.TestUtils.Companion.testData1
+import com.wafflestudio.webgam.domain.event.repository.ObjectEventRepository
+import com.wafflestudio.webgam.domain.`object`.repository.PageObjectRepository
+import com.wafflestudio.webgam.domain.page.repository.ProjectPageRepository
+import com.wafflestudio.webgam.domain.project.dto.ProjectDto.*
+import com.wafflestudio.webgam.domain.project.exception.NonAccessibleProjectException
+import com.wafflestudio.webgam.domain.project.exception.ProjectNotFoundException
+import com.wafflestudio.webgam.domain.project.repository.ProjectRepository
+import com.wafflestudio.webgam.domain.user.repository.UserRepository
+import com.wafflestudio.webgam.global.config.TestQueryDslConfig
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.collections.shouldNotContainAnyOf
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@Import(TestQueryDslConfig::class)
+@ActiveProfiles("test")
+@DisplayName("Project Service-Repository 테스트")
+class ProjectServiceTestWithRepository(
+    private val userRepository: UserRepository,
+    private val projectRepository: ProjectRepository,
+    private val projectPageRepository: ProjectPageRepository,
+    private val pageObjectRepository: PageObjectRepository,
+    private val objectEventRepository: ObjectEventRepository,
+): BehaviorSpec() {
+
+    private val projectService = ProjectService(projectRepository, userRepository)
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    override suspend fun afterSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            userRepository.deleteAll()
+        }
+    }
+
+    init {
+        this.Given("testData1") {
+            val data = testData1()
+            userRepository.saveAll(data)
+
+            val undeletedProjects = data.map { it.projects }.flatten().filter { !it.isDeleted }
+            val deletedProjects = data.map { it.projects }.flatten().filter { !it.isDeleted }
+            When("프로젝트 전체 목록을 조회하면") {
+                val response = shouldNotThrowAny { projectService.getProjectList(0, 20) }
+
+                Then("삭제되지 않은 프로젝트들이 목록으로 조회된다") {
+                    response.content shouldContainExactlyInAnyOrder undeletedProjects.map { SimpleResponse(it) }
+                    response.numberOfElements shouldBe undeletedProjects.size
+                }
+                Then("삭제된 프로젝트들은 목록에 포함되지 않는다") {
+                    if (deletedProjects.isNotEmpty())
+                        response.content shouldNotContainAnyOf deletedProjects
+                }
+            }
+
+            data.filter { !it.isDeleted }.forEach { user ->
+                When("유저 ID로 프로젝트로 목록을 조회하면: ${user.username}") {
+                    val undeletedUserProjects = user.projects.filter { !it.isDeleted }
+                    val deletedUserProjects = user.projects.filter { it.isDeleted }
+                    val response = shouldNotThrowAny { projectService.getUserProject(user.id) }
+
+                    Then("삭제되지 않은 프로젝트들이 목록으로 조회된다") {
+                        response.data shouldContainExactlyInAnyOrder undeletedUserProjects.map { SimpleResponse(it) }
+                        response.count shouldBe undeletedUserProjects.size
+                    }
+                    Then("삭제된 프로젝트들은 목록에 포함되지 않는다") {
+                        if (deletedUserProjects.isNotEmpty())
+                            response.data shouldNotContainAnyOf deletedUserProjects
+                    }
+                }
+            }
+
+            data.filter { !it.isDeleted }.forEach { user ->
+                val normalUserProjects = user.projects.filter { !it.isDeleted }
+                val deletedUserProjects = user.projects.filter { it.isDeleted }
+                val nonAccessibleProjects = data.filter { it.id != user.id }.map { it.projects }.flatten().filter { !it.isDeleted }
+
+                normalUserProjects.forEach { project ->
+                    When("일반적으로 유저 ID와 프로젝트 ID로 조회하면") {
+                        val foundProject = projectRepository.findUndeletedProjectById(project.id)
+                        val response = shouldNotThrowAny { projectService.getProject(user.id, project.id) }
+
+                        Then("저장된 프로젝트가 조회된다") {
+                            foundProject shouldBe project
+                            response shouldBe DetailedResponse(project)
+                        }
+                    }
+                }
+
+                deletedUserProjects.forEach { project ->
+                    When("삭제된 프로젝트 접근하면: ${user.username} ${project.title}") {
+                        Then("ProjectNotFoundException 예외가 발생한다") {
+                            shouldThrow<ProjectNotFoundException> {
+                                projectService.getProject(user.id, project.id)
+                            }
+                            shouldThrow<ProjectNotFoundException> {
+                                projectService.patchProject(user.id, project.id, PatchRequest("patch-project"))
+                            }
+                            shouldThrow<ProjectNotFoundException> {
+                                projectService.deleteProject(user.id, project.id)
+                            }
+                        }
+                    }
+                }
+
+                nonAccessibleProjects.forEach { project ->
+                    When("접근권한이 없는 페이지에 접근하면: ${user.username} ${project.title}") {
+                        Then("NonAccessibleProjectException 예외가 발생한다") {
+                            shouldThrow<NonAccessibleProjectException> {
+                                projectService.getProject(user.id, project.id)
+                            }
+                            shouldThrow<NonAccessibleProjectException> {
+                                projectService.patchProject(user.id, project.id, PatchRequest("patch-project"))
+                            }
+                            shouldThrow<NonAccessibleProjectException> {
+                                projectService.deleteProject(user.id, project.id)
+                            }
+                        }
+                    }
+                }
+            }
+
+            When("프로젝트를 생성하면") {
+                val user = data.first { it.username == "user-01" }
+                val request = CreateRequest("create-project")
+                val response = shouldNotThrowAny { projectService.createProject(user.id, request) }
+                val foundProject = projectRepository.findByIdOrNull(response.id)!!
+
+                Then("정상적으로 DB에 저장된다") {
+                    response shouldBe DetailedResponse(foundProject)
+                    response.title shouldBe request.title
+                }
+
+                Then("성공적으로 연관관계 매핑이 이루어진다") {
+                    user.projects shouldContain foundProject
+                }
+            }
+
+            When("프로젝트를 수정하면") {
+                val user = data.first { it.username == "user-01" }
+                val project = user.projects.first { it.title == "project-01" }
+                val request = PatchRequest("patch-project")
+                val response = shouldNotThrowAny { projectService.patchProject(user.id, project.id, request) }
+                val foundProject = projectRepository.findByIdOrNull(project.id)!!
+
+                Then("정상적으로 DB에 반영된다") {
+                    foundProject shouldBe project
+                    response shouldBe DetailedResponse(foundProject)
+                    response.title shouldBe request.title
+                }
+            }
+
+            When("프로젝트를 삭제하면") {
+                val user = data.first { it.username == "user-01" }
+                val project = user.projects.first { it.title == "project-01" }
+                shouldNotThrowAny { projectService.deleteProject(user.id, project.id) }
+                val foundProject = projectRepository.findByIdOrNull(project.id)!!
+
+                Then("정상적으로 DB에 반영된다") {
+                    foundProject shouldBe project
+                    foundProject.isDeleted shouldBe true
+                }
+
+                Then("프로젝트 조회, 수정, 삭제가 더 이상 불가능하다") {
+                    shouldThrow<ProjectNotFoundException> { projectService.getProject(user.id, project.id) }
+                    shouldThrow<ProjectNotFoundException> { projectService.patchProject(user.id, project.id, PatchRequest("patch-project")) }
+                    shouldThrow<ProjectNotFoundException> { projectService.deleteProject(user.id, project.id) }
+                }
+
+                Then("하위 페이지, 오브젝트, 이벤트들도 삭제된다") {
+                    project.pages.forEach { page ->
+                        val foundPage = projectPageRepository.findByIdOrNull(page.id)!!
+
+                        foundPage shouldBe page
+                        foundPage.isDeleted shouldBe true
+
+                        page.objects.forEach { pageObject ->
+                            val foundObject = pageObjectRepository.findByIdOrNull(pageObject.id)!!
+
+                            foundObject shouldBe pageObject
+                            foundObject.isDeleted shouldBe true
+
+                            pageObject.events.forEach { event ->
+                                val foundEvent = objectEventRepository.findByIdOrNull(event.id)!!
+
+                                foundEvent shouldBe event
+                                foundEvent.isDeleted shouldBe true
+                            }
+                        }
+                    }
+                }
+
+                Then("모든 프로젝트 목록 조회에서도 제외된다") {
+                    val response = shouldNotThrowAny { projectService.getProjectList(0, 20) }
+                    response.content shouldNotContain SimpleResponse(project)
+                }
+
+                Then("유저의 프로젝트 목록 조회에서도 제외된다") {
+                    val response = shouldNotThrowAny { projectService.getUserProject(user.id) }
+                    response.data shouldNotContain SimpleResponse(project)
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,27 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    url: jdbc:h2:mem:test
+
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        auto_quote_keyword: true
+        format_sql: true
+        use_sql_comments: true
+        highlight_sql: true
+        generate_statistics: true
+
+logging:
+  level:
+    org.springframework.security: TRACE
+    org.springframework.transaction: TRACE
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.sql: DEBUG
+    org.hibernate.stat: DEBUG


### PR DESCRIPTION
### 변경 내용

- 버그 수정
  - Fix #11 
  - Fix #12 
  - Fix #19 

- API URL 변경 (4c21ac1873358ea0b6b7f55a014b46c6dab1b69d)
  - `/api/v1/project/**` -> `/api/v1/projects/**`
  - `/api/v1/page/**` -> `/api/v1/pages/**`
  - 그에 따른 `SecurityConfig.kt` 파일 수정
- 프로젝트, 페이지 삭제시 반환 값 없는 것으로 수정 (f02b07333b39ff62aa0cf2a2cca9abe1496d0d71)
  - 삭제 되었는데 Response를 주는 것이 이상해서 수정했습니다. Response를 보고 따로 삭제 여부를 알기 어렵기도 하구요.
- Error Handling 코드 패키지 구조 개선 (5ab3b0c5947e8ddfde9d9039d7b13cc1d4d4213c)
  - `ErrorResponse`를 dto 패키지로 옮겼습니다.
  - 기존의 `Error`인터페이스를 `ErrorTypeInterface`로 이름을 바꾸고 `ErrorType.kt` 파일 안으로 옮겼습니다.
- `PageObject`와 `ObjectEvent` 연관관계 수정 (dd348932f870cfadde36b45404cdc363a0859308)
  - 이벤트가 삭제되어도 오브젝트 PK를 계속 유지하게 하고, 활성화된 이벤트를 오브젝트 쪽에서 FK키로 관리하려 했는데, 너무 부자연스러워서 수정했습니다.
  - 오브젝트 : 이벤트를 1:N 관계로 관리하고, 어플리케이션 단에서 활성화된 이벤트를 가져오는 방식입니다
  - 이제 더 이상 **오브젝트 삭제 시 `ProjectPage`의 `triggeredEvents`에서 삭제되지 않아서** 주의가 필요합니다. 아직 이를 이용하는 경우는 없지만 추후에 사용할 경우 주의 부탁드립니다.
- 테스트 관련
  - 인메모리 테스팅으로 변경했습니다 (c2cef6b53121bcf45037194e2965ea767f67c211)
  - 테스트 코드에 데이터를 집어넣는 코드가 너무 반복적이고 가독성도 별로 좋지 않기에 따로 DSL을 만들고 데이터를 만드는 코드를 작성했습니다 (d4d1fb5e0cc12eb38fa7bb54df3c850f98692179)
  - 테스트 코드 개선 (dea44e5a401cc6a19e7df0293cec3d52207dd359)
    - project, page 테스트 코드 추가했습니다
    - 각 테스트의 역할에 맞게 코드를 분리하고, 중복되는 코드를 제거했습니다.
      - ControllerTest: Request의 유효성 검증
      - ServiceTest: mocking을 이용한 비즈니스 로직만 검증
      - RepositoryTest: 쿼리 검증
      - ServiceTestWithRepostiry: 실제 데이터로 비즈니스 로직 검증
- API 문서 개선 (bbe3eae21254dcb2405302b268c6a375fd7a71f7)
  - Resolve #17


이번 PR역시 테스트 코드로 인하여 분량이 조금 돼서, 코드는 dea44e5a401cc6a19e7df0293cec3d52207dd359 을 제외하고 보시면 될 것 같습니다